### PR TITLE
Fix agent prompt submit relay (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to Lantern, by Elves are documented here.
 
 ## [0.2.1] - 2026-08-19
 
+### Changed
+
+- Cursor `agent` default model is `cursor-grok-4.6-high-fast` (Grok 4.6
+  High Fast) when `HELPER_MODEL` is empty.
+
 ### Fixed
 
-- `bin/herdr` now relays `agent prompt` with `--wait`, and when Herdr
-  reports a stalled submit (text typed but Enter ignored — common on idle
-  Cursor panes), sends Enter and waits again before returning.
+- `bin/herdr` now relays `agent prompt` with `--wait`. If Herdr reports a
+  stalled submit (text typed but Enter ignored — common on idle Cursor
+  panes), it sends Enter and waits again. Prompt rules tell the helper to
+  read the pane before saying the message was sent.
 
 ## [0.2.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.2.1] - 2026-08-19
+
+### Fixed
+
+- `bin/herdr` now relays `agent prompt` with `--wait`, and when Herdr
+  reports a stalled submit (text typed but Enter ignored — common on idle
+  Cursor panes), sends Enter and waits again before returning.
+
 ## [0.2.0] - 2026-08-18
 
 First named release. Plugin id is `aigora.lantern`. GitHub repo is

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Leave `HELPER_AGENT` empty to use the first of `agent`, `devin`, `claude`, `code
 
 | Helper you want | Install that CLI | `helper.conf` |
 | --- | --- | --- |
-| Cursor Ultra | Cursor CLI on `PATH` as `agent` (also `cursor-agent`) | `HELPER_AGENT="agent"` · `HELPER_MODEL="composer-2.5-fast"` (empty also defaults to that) · `HELPER_PERMISSION="smart"` (`--auto-review`) |
+| Cursor Ultra | Cursor CLI on `PATH` as `agent` (also `cursor-agent`) | `HELPER_AGENT="agent"` · `HELPER_MODEL="cursor-grok-4.6-high-fast"` (empty also defaults to that) · `HELPER_PERMISSION="smart"` (`--auto-review`) |
 | Devin | [Devin CLI](https://docs.devin.ai) — typically `~/.local/bin/devin` | `HELPER_AGENT="devin"` · leave `HELPER_MODEL` empty (Free rejects `--model`; Devin uses `~/.config/devin/config.json`) · `HELPER_PERMISSION="smart"` |
 | Claude Code | [Claude Code](https://code.claude.com/docs) on `PATH` as `claude` | `HELPER_AGENT="claude"` · optional `HELPER_MODEL` · optional `HELPER_EFFORT` (`--effort`) |
 | Codex | [Codex CLI](https://github.com/openai/codex) on `PATH` as `codex` | `HELPER_AGENT="codex"` · optional `HELPER_MODEL` · optional `HELPER_EFFORT` (`model_reasoning_effort`) |
@@ -59,7 +59,7 @@ $EDITOR "$(herdr plugin config-dir aigora.lantern)/helper.conf"
 
 ```sh
 HELPER_AGENT="agent"         # agent, devin, claude, codex, grok; empty = first on PATH
-HELPER_MODEL="composer-2.5-fast"  # optional --model; leave empty for Devin
+HELPER_MODEL="cursor-grok-4.6-high-fast"  # optional --model; leave empty for Devin
 HELPER_EFFORT=""             # unused for Devin and Cursor agent
 HELPER_CWD="~"               # search root mentioned to the helper
 HELPER_SPAWN_KIND="claude"   # default --kind for `herdr agent start`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.2.0** — a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.2.1** — a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 

--- a/bin/herdr
+++ b/bin/herdr
@@ -18,6 +18,10 @@ fi
 
 case ${HERDR_HELPER_OK:-} in
 1 | yes | true)
+    if helper_is_agent_prompt "$@"; then
+        helper_relay_agent_prompt "$real" "$@"
+        exit $?
+    fi
     exec "$real" "$@"
     ;;
 esac

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.2.0 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.2.1 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -371,7 +371,7 @@ No Elves install required. If there are no
           <tr>
             <td>Cursor</td>
             <td>Cursor CLI as <code>agent</code></td>
-            <td><code>HELPER_AGENT="agent"</code> · <code>HELPER_MODEL="composer-2.5-fast"</code> · <code>smart</code> uses <code>--auto-review</code></td>
+            <td><code>HELPER_AGENT="agent"</code> · <code>HELPER_MODEL="cursor-grok-4.6-high-fast"</code> · <code>smart</code> uses <code>--auto-review</code></td>
           </tr>
           <tr>
             <td>Devin</td>
@@ -397,7 +397,7 @@ No Elves install required. If there are no
       </table>
       <pre>$EDITOR "$(herdr plugin config-dir aigora.lantern)/helper.conf"</pre>
       <pre>HELPER_AGENT="agent"
-HELPER_MODEL="composer-2.5-fast"
+HELPER_MODEL="cursor-grok-4.6-high-fast"
 HELPER_EFFORT=""
 HELPER_CWD="~"
 HELPER_SPAWN_KIND="claude"

--- a/helper.conf.example
+++ b/helper.conf.example
@@ -7,7 +7,7 @@
 HELPER_AGENT=""
 
 # Optional --model. For devin, leave empty (uses ~/.config/devin/config.json).
-# For Cursor `agent`, empty defaults to composer-2.5-fast.
+# For Cursor `agent`, empty defaults to cursor-grok-4.6-high-fast.
 HELPER_MODEL=""
 
 # Optional reasoning effort. Mapped per agent:

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.2.0"
+version = "0.2.1"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos"]

--- a/howto.html
+++ b/howto.html
@@ -219,7 +219,7 @@
         <tr>
           <td>Cursor</td>
           <td>Cursor CLI as <code>agent</code> (Ultra / Composer)</td>
-          <td><code>HELPER_AGENT="agent"</code>. <code>HELPER_MODEL="composer-2.5-fast"</code>. <code>HELPER_PERMISSION</code> <code>smart</code> uses <code>--auto-review</code>.</td>
+          <td><code>HELPER_AGENT="agent"</code>. <code>HELPER_MODEL="cursor-grok-4.6-high-fast"</code>. <code>HELPER_PERMISSION</code> <code>smart</code> uses <code>--auto-review</code>.</td>
         </tr>
         <tr>
           <td>Devin</td>
@@ -248,7 +248,7 @@
     <h2>Edit your config</h2>
     <pre>$EDITOR "$(herdr plugin config-dir aigora.lantern)/helper.conf"</pre>
     <pre>HELPER_AGENT="agent"
-HELPER_MODEL="composer-2.5-fast"
+HELPER_MODEL="cursor-grok-4.6-high-fast"
 HELPER_EFFORT=""
 HELPER_CWD="~"
 HELPER_SPAWN_KIND="claude"

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.2.0</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.2.1</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>

--- a/launch.sh
+++ b/launch.sh
@@ -105,6 +105,9 @@ Runtime (injected by launch.sh; do not ignore):
   are blocked until the user confirms the exact path or target. Then rerun:
     HERDR_HELPER_OK=1 herdr <same command>
   Never call /opt/homebrew/bin/herdr or another absolute herdr path.
+- \`herdr agent prompt\` through the wrapper adds \`--wait\` and retries
+  with Enter when the target pane stalls (Cursor often types into the
+  follow-up field without submitting). Read the pane before saying sent.
 - Default --kind for agent start is $HELPER_SPAWN_KIND unless the user names one.
 - After workspace create, if agent start fails, wait two seconds and retry once
   (the new pane may still be coming up to a shell prompt).

--- a/launch.sh
+++ b/launch.sh
@@ -155,7 +155,7 @@ mkdir -p "$workdir/.cursor/rules" || die "could not create cursor rules dir"
     die "could not write cursor rule file"
 
 if [ "$helper_bin" = "agent" ] && [ -z "$HELPER_MODEL" ]; then
-    HELPER_MODEL=composer-2.5-fast
+    HELPER_MODEL=cursor-grok-4.6-high-fast
 fi
 
 set -- "$helper_bin"

--- a/lib.sh
+++ b/lib.sh
@@ -146,6 +146,42 @@ helper_is_inspect() {
     return 1
 }
 
+helper_argv_has_flag() {
+    _helper_flag=$1
+    shift
+    while [ $# -gt 0 ]; do
+        [ "$1" = "$_helper_flag" ] && return 0
+        shift
+    done
+    return 1
+}
+
+helper_is_agent_prompt() {
+    [ "${1:-}" = agent ] && [ "${2:-}" = prompt ] && [ -n "${3:-}" ] && [ -n "${4:-}" ]
+}
+
+helper_relay_agent_prompt() {
+    # Submit through Herdr with --wait, then Enter + wait if the pane never
+    # leaves idle (common when Cursor keeps text in the follow-up field).
+    _helper_real=$1
+    shift
+    _helper_target=$3
+    _helper_text=$4
+    shift 4
+    _helper_extra=
+    if ! helper_argv_has_flag --wait "$@"; then
+        _helper_extra="--wait --timeout 120000"
+    elif ! helper_argv_has_flag --timeout "$@"; then
+        _helper_extra="--timeout 120000"
+    fi
+    # shellcheck disable=SC2086
+    if "$_helper_real" agent prompt "$_helper_target" "$_helper_text" "$@" $_helper_extra; then
+        return 0
+    fi
+    "$_helper_real" agent send-keys "$_helper_target" Enter || return $?
+    "$_helper_real" agent wait "$_helper_target" --timeout 120000
+}
+
 helper_resolve_real_herdr() {
     if [ -n "${HERDR_REAL:-}" ] && [ -x "$HERDR_REAL" ]; then
         printf '%s' "$HERDR_REAL"

--- a/prompt.md
+++ b/prompt.md
@@ -21,6 +21,10 @@ beyond this list.
    - If that workspace already has an agent, use it (focus, then
      `herdr agent prompt` if they have a task). Start a new agent only
      when they ask for another and a pane is at a shell prompt.
+   - Relay a message: `HERDR_HELPER_OK=1 herdr agent prompt <target>
+     "<text>"`. The wrapper adds `--wait` and, if the pane stalls with
+     text still in the input field (common on Cursor), sends Enter and
+     waits again. Read the pane before telling the user it was sent.
    - To seat: `herdr workspace create --cwd <dir> --label <label> --no-focus`
      (JSON: `.result.root_pane.pane_id`), then
      `herdr agent start <slug> --kind <kind> --pane <pane_id>`, optionally

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -19,7 +19,8 @@ done
 tmp=$(mktemp)
 err=$(mktemp)
 fake=
-trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"' EXIT
+fake_prompt=
+trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"' EXIT
 
 printf '%s\n' 'HELPER_AGENT="devin"' 'HELPER_SPAWN_KIND="claude"' >"$tmp"
 HELPER_AGENT=""
@@ -63,6 +64,41 @@ export HERDR_HELPER_OK=1
 out=$(sh "$root/bin/herdr" workspace create --cwd /tmp --label x) ||
     fail "mutate with OK should pass"
 printf '%s\n' "$out" | grep -q 'workspace create' || fail "OK mutate did not exec real herdr"
+
+fake_prompt=$(mktemp -d)
+cat >"$fake_prompt/herdr" <<'EOF'
+#!/bin/sh
+case "$1 $2" in
+"agent prompt")
+    if [ "$5" = --wait ]; then
+        exit 1
+    fi
+    printf 'agent prompt %s\n' "$3"
+    exit 0
+    ;;
+"agent send-keys")
+    printf 'agent send-keys %s %s\n' "$3" "$4"
+    exit 0
+    ;;
+"agent wait")
+    printf 'agent wait %s\n' "$3"
+    exit 0
+    ;;
+esac
+printf '%s\n' "$*"
+exit 0
+EOF
+chmod +x "$fake_prompt/herdr"
+export HERDR_REAL="$fake_prompt/herdr"
+export HERDR_HELPER_OK=1
+out=$(sh "$root/bin/herdr" agent prompt w1:p1 "hello there") ||
+    fail "prompt relay should succeed after Enter fallback"
+printf '%s\n' "$out" | grep -q 'agent send-keys w1:p1 Enter' ||
+    fail "prompt relay did not send Enter fallback"
+printf '%s\n' "$out" | grep -q 'agent wait w1:p1' ||
+    fail "prompt relay did not wait after Enter"
+unset HERDR_REAL
+fake_prompt=
 
 python3 "$root/bin/elves-floor" --root /tmp >/dev/null || fail "elves-floor"
 python3 -m py_compile "$root/bin/elves-floor" "$root/bin/goals-floor" || fail "py_compile"


### PR DESCRIPTION
## Summary
- Relay `herdr agent prompt` through the Lantern wrapper with `--wait`, and on stalled submit send Enter plus `agent wait` (fixes Cursor typing into the follow-up field without submitting).
- Document the relay behavior in `prompt.md` and the launch runtime appendix.
- Bump plugin version to **0.2.1**.

## Test plan
- [x] `sh tests/smoke.sh` (includes fake-herdr relay test for Enter fallback)
- [ ] After merge: `herdr plugin install aigorahub/herdr-lantern` (or link local checkout) and relay a message to an idle Cursor pane
- [ ] Confirm the agent receives and responds without manual Enter


Made with [Cursor](https://cursor.com)