### PR TITLE
Seat the lantern as a chat in its own workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/__pycache__/
 __pycache__/
 *.pyc
 .DS_Store
+state/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- Lantern is a normal chat in its own workspace, not a lightbox. The pane
+  placement is `tab`, and the 90% width and height are gone.
+- `open.sh` seats that chat. The first open creates a workspace labelled
+  `lantern` with `--cwd $HOME`, opens the chat as a tab in it, and closes
+  the empty shell tab the new workspace comes with. Later opens focus that
+  same workspace and the chat already in it, so there is never a second
+  lantern workspace. The workspace and pane ids are remembered under the
+  plugin state directory (`workspace.id`, `pane.id`); the `lantern` label
+  is the fallback.
+- The open path is unchanged: `hsh`, `prefix+H`, or
+  `herdr plugin action invoke aigora.lantern.open`.
+- A new workspace lands last in the sidebar. Lantern does not pin it to the
+  top; drag it where you want it.
+- The chat process still runs in the plugin state workdir. Home is only
+  where the workspace sits and the `HELPER_CWD` search root.
+- Prompt and docs: close the chat by quitting the helper CLI, as before.
+  The tab closes with it, and the lantern workspace closes when that chat
+  was the only tab. Escape still stays inside the CLI. The helper is told
+  not to close its own workspace or seat other agents in it.
+
 ## [0.2.1] - 2026-08-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ All notable changes to Lantern, by Elves are documented here.
 - Lantern is a normal chat in its own workspace, not a lightbox. The pane
   placement is `tab`, and the 90% width and height are gone.
 - `open.sh` seats that chat. The first open creates a workspace labelled
-  `lantern` with `--cwd $HOME`, opens the chat as a tab in it, and closes
-  the empty shell tab the new workspace comes with. Later opens focus that
-  same workspace and the chat already in it, so there is never a second
-  lantern workspace. The workspace and pane ids are remembered under the
-  plugin state directory (`workspace.id`, `pane.id`); the `lantern` label
-  is the fallback.
+  `🏮 lantern` with `--cwd $HOME`, opens the chat there as a tab named
+  `field`, and closes the empty shell tab the new workspace comes with.
+  Later opens focus that same workspace and the chat already in it, so
+  there is never a second lantern workspace. The workspace and pane ids
+  are remembered under the plugin state directory (`workspace.id`,
+  `pane.id`); the `🏮 lantern` label, then a plain `lantern` label, are
+  the fallbacks. Rename the workspace or the tab and the ids still work.
 - The open path is unchanged: `hsh`, `prefix+H`, or
   `herdr plugin action invoke aigora.lantern.open`.
 - A new workspace lands last in the sidebar. Lantern does not pin it to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ All notable changes to Lantern, by Elves are documented here.
 - Lantern is a normal chat in its own workspace, not a lightbox. The pane
   placement is `tab`, and the 90% width and height are gone.
 - `open.sh` seats that chat. The first open creates a workspace labelled
-  `🏮 lantern` with `--cwd $HOME`, opens the chat there as a tab named
+  `🪔 lantern` with `--cwd $HOME`, opens the chat there as a tab named
   `field`, and closes the empty shell tab the new workspace comes with.
-  Later opens focus that same workspace and the chat already in it, so
-  there is never a second lantern workspace. The workspace and pane ids
-  are remembered under the plugin state directory (`workspace.id`,
-  `pane.id`); the `🏮 lantern` label, then a plain `lantern` label, are
-  the fallbacks. Rename the workspace or the tab and the ids still work.
+- Later opens focus a chat that is still running, wherever the tab was
+  moved, or seat a new one in the same workspace. Lantern does not open a
+  second lantern workspace, and a lock stops two fast opens racing into
+  two.
+- The workspace and pane ids are remembered under the plugin state
+  directory (`workspace.id`, `pane.id`) and checked before use. Herdr
+  reuses ids after a restart, so a remembered workspace counts only while
+  it still carries the `🪔 lantern` label, and a remembered pane only
+  while it is still a lantern chat. Otherwise Lantern looks up the label,
+  then creates the workspace.
+- A chat that fails to start no longer leaves an empty workspace behind.
 - The open path is unchanged: `hsh`, `prefix+H`, or
   `herdr plugin action invoke aigora.lantern.open`.
 - A new workspace lands last in the sidebar. Lantern does not pin it to the

--- a/README.md
+++ b/README.md
@@ -119,15 +119,18 @@ script or config edits; reopen the lantern.
 
 ## Where it sits
 
-The first open creates a workspace labelled **lantern** at your home
-directory and seats the chat there as a tab. It does not drop a tab into
-whatever workspace you are in, and it closes the empty shell tab the new
-workspace comes with, so the workspace holds the chat alone.
+The first open creates a workspace labelled **🏮 lantern** at your home
+directory and seats the chat there as a tab named **field**. It does not
+drop a tab into whatever workspace you are in, and it closes the empty
+shell tab the new workspace comes with, so the workspace holds the chat
+alone. The lantern in the sidebar is how you find it at a glance.
 
 Every later open reuses that workspace: Herdr focuses it and the chat
 already in it. You never get a second lantern workspace. Lantern
 remembers the workspace and pane ids under the plugin state directory
-(`workspace.id`, `pane.id`) and falls back to the `lantern` label.
+(`workspace.id`, `pane.id`), then falls back to the `🏮 lantern` label and
+to a plain `lantern` label if you made one by hand. Rename the workspace
+or the tab whenever you like; the remembered ids keep working.
 
 A new workspace lands **last** in the sidebar. There is no pin-to-top;
 drag it where you want it.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ the field: who needs you, what they are working toward, jump to a pane,
 start a new agent. The sidebar already marks working, blocked, done, or
 idle. This plugin does not replace Herdr or wrap the agent CLIs.
 
-It opens at 90% and starts the helper CLI you already use (Cursor `agent`,
-Devin, Claude Code, Codex, or Grok). That CLI drives `herdr`.
+It opens as a chat tab in its own Herdr workspace and starts the helper CLI
+you already use (Cursor `agent`, Devin, Claude Code, Codex, or Grok). That
+CLI drives `herdr`.
 
 Requires Herdr **0.7.5+** on macOS or Linux.
 
@@ -36,7 +37,7 @@ Do not run link and GitHub install at the same time for the same plugin id.
 
 ## Pick your helper CLI
 
-The popup runs **one** CLI as the lantern. That is independent of
+The lantern chat runs **one** CLI. That is independent of
 `HELPER_SPAWN_KIND`, which is only the default `--kind` when the helper starts
 an agent for your work (usually `claude`).
 
@@ -114,9 +115,30 @@ description = "Open lantern"
 ```
 
 Then `herdr server reload-config`. No Herdr restart is needed for plugin
-script or config edits; reopen the popup.
+script or config edits; reopen the lantern.
 
-The popup closes when the agent exits. Herdr does not take Escape until then.
+## Where it sits
+
+The first open creates a workspace labelled **lantern** at your home
+directory and seats the chat there as a tab. It does not drop a tab into
+whatever workspace you are in, and it closes the empty shell tab the new
+workspace comes with, so the workspace holds the chat alone.
+
+Every later open reuses that workspace: Herdr focuses it and the chat
+already in it. You never get a second lantern workspace. Lantern
+remembers the workspace and pane ids under the plugin state directory
+(`workspace.id`, `pane.id`) and falls back to the `lantern` label.
+
+A new workspace lands **last** in the sidebar. There is no pin-to-top;
+drag it where you want it.
+
+The chat runs in the plugin state workdir. Home is only where the
+workspace sits and the search root the helper is told about
+(`HELPER_CWD`). Your repositories keep their own workspaces.
+
+The tab closes when the helper CLI exits, and the lantern workspace goes
+with it when that chat was the only tab in it. Herdr does not take Escape
+until then; Escape stays inside the CLI.
 
 For Cursor `agent`: **Ctrl+C** (twice if a turn is running), or **Ctrl+D** on an
 empty prompt.

--- a/README.md
+++ b/README.md
@@ -119,18 +119,24 @@ script or config edits; reopen the lantern.
 
 ## Where it sits
 
-The first open creates a workspace labelled **🏮 lantern** at your home
+The first open creates a workspace labelled **🪔 lantern** at your home
 directory and seats the chat there as a tab named **field**. It does not
 drop a tab into whatever workspace you are in, and it closes the empty
 shell tab the new workspace comes with, so the workspace holds the chat
 alone. The lantern in the sidebar is how you find it at a glance.
 
-Every later open reuses that workspace: Herdr focuses it and the chat
-already in it. You never get a second lantern workspace. Lantern
-remembers the workspace and pane ids under the plugin state directory
-(`workspace.id`, `pane.id`), then falls back to the `🏮 lantern` label and
-to a plain `lantern` label if you made one by hand. Rename the workspace
-or the tab whenever you like; the remembered ids keep working.
+Every later open reuses it. A chat that is still running is focused
+wherever it sits, so moving or renaming that tab is safe. If the chat has
+exited, Lantern seats a new one in the same workspace and closes nothing
+else. It does not open a second lantern workspace, and two fast key
+presses cannot race into two.
+
+Lantern remembers both ids under the plugin state directory
+(`workspace.id`, `pane.id`) and checks them before it uses them: Herdr
+reuses ids after a restart, so a remembered workspace counts only while it
+still carries the `🪔 lantern` label, and a remembered pane only while it
+is still a lantern chat. Keep that label if you want the workspace reused
+after the chat closes. Rename it and the next open makes a fresh one.
 
 A new workspace lands **last** in the sidebar. There is no pin-to-top;
 drag it where you want it.

--- a/docs/index.html
+++ b/docs/index.html
@@ -251,7 +251,7 @@
 
     <div class="wrap">
       <h2>What it is</h2>
-      <p>A Herdr plugin from the team that brought you <a href="https://github.com/aigorahub/elves">Elves</a>. It opens a 90% popup and starts the CLI you already use — Cursor <code>agent</code>, Devin, Claude Code, Codex, or Grok. That CLI drives Herdr. It is not a new chat product, and it does not cobble or land PRs.</p>
+      <p>A Herdr plugin from the team that brought you <a href="https://github.com/aigorahub/elves">Elves</a>. It opens as a chat tab in its own Herdr workspace and starts the CLI you already use — Cursor <code>agent</code>, Devin, Claude Code, Codex, or Grok. That CLI drives Herdr. It is not a new chat product, and it does not cobble or land PRs.</p>
       <p class="note">The sidebar already marks working, blocked, done, or idle. Lantern adds goals and progress in words, then seats or focuses a pane when you ask.</p>
 
       <h2>Install</h2>
@@ -290,6 +290,30 @@
         </li>
       </ol>
       <p class="note">Close by quitting the helper CLI. Escape stays inside the CLI. Cursor <code>agent</code>: <kbd>ctrl+c</kbd> (twice if a turn is running), or <kbd>ctrl+d</kbd> on an empty prompt.</p>
+
+      <h2>Where it sits</h2>
+      <ol class="steps">
+        <li>
+          <div>
+            The first open creates a workspace labelled <code>lantern</code> at your home directory
+            and seats the chat there as a tab. Nothing is dropped into the workspace you are working
+            in, and the empty shell tab of the new workspace is closed, so the chat sits alone.
+          </div>
+        </li>
+        <li>
+          <div>
+            Every later open reuses that workspace: Herdr focuses it and the chat already in it.
+            You never get a second lantern workspace.
+          </div>
+        </li>
+        <li>
+          <div>
+            The new workspace lands last in the sidebar. There is no pin-to-top; drag it where you
+            want it.
+          </div>
+        </li>
+      </ol>
+      <p class="note">The chat runs in the plugin state workdir. Home is only where the workspace sits and the search root the helper is told about (<code>HELPER_CWD</code>). Your repositories keep their own workspaces. When the helper CLI exits, the tab closes, and the lantern workspace closes with it if that chat was the only tab.</p>
     </div>
 
     <div class="wrap wide">
@@ -298,7 +322,7 @@
       <div class="shots">
         <figure class="shot">
           <div class="frame">
-            <div class="chrome"><span class="dot live"></span> Lantern · Cursor agent · 90%</div>
+            <div class="chrome"><span class="dot live"></span> Lantern · Cursor agent · lantern workspace</div>
             <pre class="term"><span class="dim">THE HERD IN THE FIELD</span>
 
 <span class="need">NEEDS YOU</span>
@@ -362,7 +386,7 @@ No Elves install required. If there are no
       </ul>
 
       <h2>Pick your helper CLI</h2>
-      <p>The popup is one CLI. That is yours. It is not a shared team model. <code>HELPER_SPAWN_KIND</code> is separate: the default <code>--kind</code> when Lantern starts an agent for your work (usually <code>claude</code>).</p>
+      <p>The lantern chat is one CLI. That is yours. It is not a shared team model. <code>HELPER_SPAWN_KIND</code> is separate: the default <code>--kind</code> when Lantern starts an agent for your work (usually <code>claude</code>).</p>
       <table>
         <thead>
           <tr><th>Helper</th><th>Install</th><th>Your helper.conf</th></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,7 +295,7 @@
       <ol class="steps">
         <li>
           <div>
-            The first open creates a workspace labelled <code>🏮 lantern</code> at your home
+            The first open creates a workspace labelled <code>🪔 lantern</code> at your home
             directory and seats the chat there as a tab named <code>field</code>. Nothing is dropped
             into the workspace you are working in, and the empty shell tab of the new workspace is
             closed, so the chat sits alone. The lantern in the sidebar is how you spot it.
@@ -303,9 +303,9 @@
         </li>
         <li>
           <div>
-            Every later open reuses that workspace: Herdr focuses it and the chat already in it.
-            You never get a second lantern workspace. Rename the workspace or the tab if you want
-            to; the remembered ids keep working.
+            Every later open reuses it. A chat that is still running is focused wherever it sits, so
+            moving or renaming that tab is safe. If it has exited, a new chat is seated in the same
+            workspace. Lantern does not open a second lantern workspace.
           </div>
         </li>
         <li>
@@ -315,7 +315,7 @@
           </div>
         </li>
       </ol>
-      <p class="note">The chat runs in the plugin state workdir. Home is only where the workspace sits and the search root the helper is told about (<code>HELPER_CWD</code>). Your repositories keep their own workspaces. When the helper CLI exits, the tab closes, and the lantern workspace closes with it if that chat was the only tab.</p>
+      <p class="note">The chat runs in the plugin state workdir. Home is only where the workspace sits and the search root the helper is told about (<code>HELPER_CWD</code>). Your repositories keep their own workspaces. When the helper CLI exits, the tab closes, and the lantern workspace closes with it if that chat was the only tab. Herdr reuses workspace and pane ids after a restart, so Lantern checks the remembered ids before it trusts them: keep the <code>🪔 lantern</code> label if you want that workspace reused after the chat closes.</p>
     </div>
 
     <div class="wrap wide">
@@ -324,7 +324,7 @@
       <div class="shots">
         <figure class="shot">
           <div class="frame">
-            <div class="chrome"><span class="dot live"></span> 🏮 lantern · field · Cursor agent</div>
+            <div class="chrome"><span class="dot live"></span> 🪔 lantern · field · Cursor agent</div>
             <pre class="term"><span class="dim">THE HERD IN THE FIELD</span>
 
 <span class="need">NEEDS YOU</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,15 +295,17 @@
       <ol class="steps">
         <li>
           <div>
-            The first open creates a workspace labelled <code>lantern</code> at your home directory
-            and seats the chat there as a tab. Nothing is dropped into the workspace you are working
-            in, and the empty shell tab of the new workspace is closed, so the chat sits alone.
+            The first open creates a workspace labelled <code>🏮 lantern</code> at your home
+            directory and seats the chat there as a tab named <code>field</code>. Nothing is dropped
+            into the workspace you are working in, and the empty shell tab of the new workspace is
+            closed, so the chat sits alone. The lantern in the sidebar is how you spot it.
           </div>
         </li>
         <li>
           <div>
             Every later open reuses that workspace: Herdr focuses it and the chat already in it.
-            You never get a second lantern workspace.
+            You never get a second lantern workspace. Rename the workspace or the tab if you want
+            to; the remembered ids keep working.
           </div>
         </li>
         <li>
@@ -322,7 +324,7 @@
       <div class="shots">
         <figure class="shot">
           <div class="frame">
-            <div class="chrome"><span class="dot live"></span> Lantern · Cursor agent · lantern workspace</div>
+            <div class="chrome"><span class="dot live"></span> 🏮 lantern · field · Cursor agent</div>
             <pre class="term"><span class="dim">THE HERD IN THE FIELD</span>
 
 <span class="need">NEEDS YOU</span>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -8,13 +8,11 @@ platforms = ["linux", "macos"]
 [[panes]]
 id = "helper"
 title = "Lantern"
-placement = "popup"
-width = "90%"
-height = "90%"
+placement = "tab"
 command = ["sh", "launch.sh"]
 
 [[actions]]
 id = "open"
 title = "Open lantern"
-description = "Open the lantern popup"
+description = "Open the lantern chat in its own workspace"
 command = ["sh", "open.sh"]

--- a/howto.html
+++ b/howto.html
@@ -279,7 +279,7 @@ HELPER_EXTRA_ARGS=""</pre>
     <ol class="steps">
       <li>
         <div>
-          The first open creates a workspace labelled <code>🏮 lantern</code> at your home directory
+          The first open creates a workspace labelled <code>🪔 lantern</code> at your home directory
           and seats the chat there as a tab named <code>field</code>. It is not dropped into the
           workspace you happen to be in, and the empty shell tab of the new workspace is closed, so
           the chat sits alone. The lantern in the sidebar is how you spot it.
@@ -287,9 +287,9 @@ HELPER_EXTRA_ARGS=""</pre>
       </li>
       <li>
         <div>
-          Every later open reuses that workspace. Herdr focuses it and the chat already in it.
-          You never get a second lantern workspace. Rename the workspace or the tab if you want to;
-          the remembered ids keep working.
+          Every later open reuses it. A chat that is still running is focused wherever it sits, so
+          moving or renaming that tab is safe. If it has exited, a new chat is seated in the same
+          workspace. Lantern does not open a second lantern workspace.
         </div>
       </li>
       <li>
@@ -299,7 +299,7 @@ HELPER_EXTRA_ARGS=""</pre>
         </div>
       </li>
     </ol>
-    <p class="note">The chat runs in the plugin state workdir. Home is only where the workspace sits and the search root the helper is told about (<code>HELPER_CWD</code>). Your repositories keep their own workspaces. When the helper CLI exits, the tab closes, and the lantern workspace closes with it if that chat was the only tab.</p>
+    <p class="note">The chat runs in the plugin state workdir. Home is only where the workspace sits and the search root the helper is told about (<code>HELPER_CWD</code>). Your repositories keep their own workspaces. When the helper CLI exits, the tab closes, and the lantern workspace closes with it if that chat was the only tab. Herdr reuses workspace and pane ids after a restart, so Lantern checks the remembered ids before it trusts them: keep the <code>🪔 lantern</code> label if you want that workspace reused after the chat closes.</p>
 
     <h2>What to say</h2>
     <ul class="says">

--- a/howto.html
+++ b/howto.html
@@ -210,7 +210,7 @@
     <p class="note">Developers can <code>herdr plugin link /path/to/herdr-lantern</code> instead. Do not link and GitHub-install the same id at once.</p>
 
     <h2>Pick your helper CLI</h2>
-    <p>The popup is not a new chat UI. It launches one of the CLIs you already have. That choice is yours; it is not a shared team model.</p>
+    <p>The lantern is not a new chat UI. It launches one of the CLIs you already have. That choice is yours; it is not a shared team model.</p>
     <table>
       <thead>
         <tr><th>Helper</th><th>What to install</th><th>Your <code>helper.conf</code></th></tr>
@@ -243,7 +243,7 @@
         </tr>
       </tbody>
     </table>
-    <p class="note"><code>HELPER_SPAWN_KIND</code> is separate: it is the default <code>--kind</code> when the helper starts an agent for your work (usually <code>claude</code>), not the CLI in the popup.</p>
+    <p class="note"><code>HELPER_SPAWN_KIND</code> is separate: it is the default <code>--kind</code> when the helper starts an agent for your work (usually <code>claude</code>), not the CLI in the lantern chat.</p>
 
     <h2>Edit your config</h2>
     <pre>$EDITOR "$(herdr plugin config-dir aigora.lantern)/helper.conf"</pre>
@@ -254,7 +254,7 @@ HELPER_CWD="~"
 HELPER_SPAWN_KIND="claude"
 HELPER_PERMISSION="smart"
 HELPER_EXTRA_ARGS=""</pre>
-    <p class="note">Empty <code>HELPER_AGENT</code> picks the first of <code>agent</code> / Devin / Claude / Codex / Grok on <code>PATH</code>. Cursor with an empty model defaults to Composer 2.5 Fast. Leave Devin’s model blank.</p>
+    <p class="note">Empty <code>HELPER_AGENT</code> picks the first of <code>agent</code> / Devin / Claude / Codex / Grok on <code>PATH</code>. Cursor with an empty model defaults to Grok 4.6 High Fast. Leave Devin’s model blank.</p>
 
     <h2>Open it</h2>
     <ol class="steps">
@@ -273,7 +273,31 @@ HELPER_EXTRA_ARGS=""</pre>
         </div>
       </li>
     </ol>
-    <p class="note">Close the popup by quitting the helper CLI. Escape stays inside the CLI. For Cursor <code>agent</code>: <kbd>ctrl+c</kbd> (twice if a turn is running), or <kbd>ctrl+d</kbd> on an empty prompt. Script and config edits do not need a Herdr restart — reopen the popup.</p>
+    <p class="note">Close the chat by quitting the helper CLI. Escape stays inside the CLI. For Cursor <code>agent</code>: <kbd>ctrl+c</kbd> (twice if a turn is running), or <kbd>ctrl+d</kbd> on an empty prompt. Script and config edits do not need a Herdr restart — reopen the lantern.</p>
+
+    <h2>Where it sits</h2>
+    <ol class="steps">
+      <li>
+        <div>
+          The first open creates a workspace labelled <code>lantern</code> at your home directory
+          and seats the chat there as a tab. It is not dropped into the workspace you happen to be
+          in, and the empty shell tab of the new workspace is closed, so the chat sits alone.
+        </div>
+      </li>
+      <li>
+        <div>
+          Every later open reuses that workspace. Herdr focuses it and the chat already in it.
+          You never get a second lantern workspace.
+        </div>
+      </li>
+      <li>
+        <div>
+          The new workspace lands last in the sidebar. There is no pin-to-top; drag it where you
+          want it.
+        </div>
+      </li>
+    </ol>
+    <p class="note">The chat runs in the plugin state workdir. Home is only where the workspace sits and the search root the helper is told about (<code>HELPER_CWD</code>). Your repositories keep their own workspaces. When the helper CLI exits, the tab closes, and the lantern workspace closes with it if that chat was the only tab.</p>
 
     <h2>What to say</h2>
     <ul class="says">

--- a/howto.html
+++ b/howto.html
@@ -279,15 +279,17 @@ HELPER_EXTRA_ARGS=""</pre>
     <ol class="steps">
       <li>
         <div>
-          The first open creates a workspace labelled <code>lantern</code> at your home directory
-          and seats the chat there as a tab. It is not dropped into the workspace you happen to be
-          in, and the empty shell tab of the new workspace is closed, so the chat sits alone.
+          The first open creates a workspace labelled <code>🏮 lantern</code> at your home directory
+          and seats the chat there as a tab named <code>field</code>. It is not dropped into the
+          workspace you happen to be in, and the empty shell tab of the new workspace is closed, so
+          the chat sits alone. The lantern in the sidebar is how you spot it.
         </div>
       </li>
       <li>
         <div>
           Every later open reuses that workspace. Herdr focuses it and the chat already in it.
-          You never get a second lantern workspace.
+          You never get a second lantern workspace. Rename the workspace or the tab if you want to;
+          the remembered ids keep working.
         </div>
       </li>
       <li>

--- a/launch.sh
+++ b/launch.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Pane entrypoint: build the agent command line from the user's config and
-# exec it inside the Herdr popup. Herdr injects HERDR_PLUGIN_CONFIG_DIR,
+# exec it in the lantern pane. open.sh seats that pane as a tab in the
+# workspace labelled "lantern". Herdr injects HERDR_PLUGIN_CONFIG_DIR,
 # HERDR_PLUGIN_ROOT, HERDR_BIN_PATH, and the socket env, so the agent that
 # starts here can drive Herdr directly.
 set -u
@@ -113,8 +114,11 @@ Runtime (injected by launch.sh; do not ignore):
   (the new pane may still be coming up to a shell prompt).
 - Search from $search_root plus the usual project roots. You are the lantern,
   not an elf; do not edit files in this workdir.
-- Close this popup by exiting the helper CLI (not Escape). Cursor agent:
-  Ctrl+C, or Ctrl+D on an empty prompt.
+- You are a tab in the workspace labelled "lantern". Never close that
+  workspace, that tab, or your own pane. Reopening is \`hsh\`.
+- Close this chat by exiting the helper CLI (not Escape). Cursor agent:
+  Ctrl+C, or Ctrl+D on an empty prompt. The tab closes with the CLI, and
+  the lantern workspace closes with it when nothing else is in there.
 EOF
 )
 full_prompt=$prompt$appendix

--- a/launch.sh
+++ b/launch.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Pane entrypoint: build the agent command line from the user's config and
-# exec it in the lantern pane. open.sh seats that pane as a tab in the
-# workspace labelled "lantern". Herdr injects HERDR_PLUGIN_CONFIG_DIR,
+# exec it in the lantern pane. open.sh seats that pane as the "field" tab
+# in the workspace labelled "🏮 lantern". Herdr injects HERDR_PLUGIN_CONFIG_DIR,
 # HERDR_PLUGIN_ROOT, HERDR_BIN_PATH, and the socket env, so the agent that
 # starts here can drive Herdr directly.
 set -u
@@ -114,8 +114,8 @@ Runtime (injected by launch.sh; do not ignore):
   (the new pane may still be coming up to a shell prompt).
 - Search from $search_root plus the usual project roots. You are the lantern,
   not an elf; do not edit files in this workdir.
-- You are a tab in the workspace labelled "lantern". Never close that
-  workspace, that tab, or your own pane. Reopening is \`hsh\`.
+- You are the "field" tab in the workspace labelled "🏮 lantern". Never
+  close that workspace, that tab, or your own pane. Reopening is \`hsh\`.
 - Close this chat by exiting the helper CLI (not Escape). Cursor agent:
   Ctrl+C, or Ctrl+D on an empty prompt. The tab closes with the CLI, and
   the lantern workspace closes with it when nothing else is in there.

--- a/launch.sh
+++ b/launch.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Pane entrypoint: build the agent command line from the user's config and
 # exec it in the lantern pane. open.sh seats that pane as the "field" tab
-# in the workspace labelled "🏮 lantern". Herdr injects HERDR_PLUGIN_CONFIG_DIR,
+# in the workspace labelled "🪔 lantern". Herdr injects HERDR_PLUGIN_CONFIG_DIR,
 # HERDR_PLUGIN_ROOT, HERDR_BIN_PATH, and the socket env, so the agent that
 # starts here can drive Herdr directly.
 set -u
@@ -114,8 +114,10 @@ Runtime (injected by launch.sh; do not ignore):
   (the new pane may still be coming up to a shell prompt).
 - Search from $search_root plus the usual project roots. You are the lantern,
   not an elf; do not edit files in this workdir.
-- You are the "field" tab in the workspace labelled "🏮 lantern". Never
-  close that workspace, that tab, or your own pane. Reopening is \`hsh\`.
+- You are the "field" tab in the dedicated lantern workspace (labelled
+  "🪔 lantern" unless the user renamed it). Seat new agents in their own
+  repository workspace, never in this one. Never close this workspace,
+  this tab, or your own pane.
 - Close this chat by exiting the helper CLI (not Escape). Cursor agent:
   Ctrl+C, or Ctrl+D on an empty prompt. The tab closes with the CLI, and
   the lantern workspace closes with it when nothing else is in there.

--- a/lib.sh
+++ b/lib.sh
@@ -182,6 +182,49 @@ helper_relay_agent_prompt() {
     "$_helper_real" agent wait "$_helper_target" --timeout 120000
 }
 
+helper_json_value() {
+    # Print the first string value for a JSON key read from stdin.
+    # Splits on JSON punctuation first so the match cannot run past the
+    # field it belongs to. Only for flat string fields.
+    _helper_json_key=$1
+    tr '{},' '\n\n\n' |
+        sed -n "s/.*\"$_helper_json_key\":\"\([^\"]*\)\".*/\1/p" |
+        sed -n '1p'
+}
+
+helper_workspace_id_by_label() {
+    # $1 real herdr, $2 label. Prints the first workspace id with that label.
+    # Objects in `workspace list` are flat, so one '{' fragment is one
+    # workspace and key order does not matter.
+    "$1" workspace list 2>/dev/null |
+        tr '{' '\n' |
+        grep -F "\"label\":\"$2\"," |
+        sed -n 's/.*"workspace_id":"\([^"]*\)".*/\1/p' |
+        sed -n '1p'
+}
+
+helper_workspace_exists() {
+    # $1 real herdr, $2 workspace id.
+    [ -n "${2:-}" ] || return 1
+    "$1" workspace get "$2" >/dev/null 2>&1
+}
+
+helper_pane_is_lantern() {
+    # $1 real herdr, $2 pane id, $3 workspace id, $4 pane title.
+    # Ids are reused after a Herdr restart, so check the title and the
+    # workspace as well as existence.
+    [ -n "${2:-}" ] || return 1
+    _helper_pane_json=$("$1" pane get "$2" 2>/dev/null) || return 1
+    case $_helper_pane_json in
+    *"\"workspace_id\":\"$3\""*) ;;
+    *) return 1 ;;
+    esac
+    case $_helper_pane_json in
+    *"\"label\":\"$4\""*) return 0 ;;
+    esac
+    return 1
+}
+
 helper_resolve_real_herdr() {
     if [ -n "${HERDR_REAL:-}" ] && [ -x "$HERDR_REAL" ]; then
         printf '%s' "$HERDR_REAL"

--- a/lib.sh
+++ b/lib.sh
@@ -203,26 +203,25 @@ helper_workspace_id_by_label() {
         sed -n '1p'
 }
 
-helper_workspace_exists() {
-    # $1 real herdr, $2 workspace id.
+helper_workspace_label() {
+    # $1 real herdr, $2 workspace id. Prints the label of that workspace.
+    # Fails when the id is empty or gone.
     [ -n "${2:-}" ] || return 1
-    "$1" workspace get "$2" >/dev/null 2>&1
+    _helper_ws_json=$("$1" workspace get "$2" 2>/dev/null) || return 1
+    printf '%s' "$_helper_ws_json" | helper_json_value label
 }
 
-helper_pane_is_lantern() {
-    # $1 real herdr, $2 pane id, $3 workspace id, $4 pane title.
-    # Ids are reused after a Herdr restart, so check the title and the
-    # workspace as well as existence.
+helper_lantern_pane_workspace() {
+    # $1 real herdr, $2 pane id, $3 pane title. Prints the workspace that
+    # pane sits in, but only while it is still a live lantern chat. Herdr
+    # reuses pane ids after a restart, so the title is checked as well.
     [ -n "${2:-}" ] || return 1
     _helper_pane_json=$("$1" pane get "$2" 2>/dev/null) || return 1
     case $_helper_pane_json in
-    *"\"workspace_id\":\"$3\""*) ;;
+    *"\"label\":\"$3\""*) ;;
     *) return 1 ;;
     esac
-    case $_helper_pane_json in
-    *"\"label\":\"$4\""*) return 0 ;;
-    esac
-    return 1
+    printf '%s' "$_helper_pane_json" | helper_json_value workspace_id
 }
 
 helper_resolve_real_herdr() {

--- a/lib.sh
+++ b/lib.sh
@@ -232,19 +232,21 @@ helper_lantern_pane_in_workspace() {
     # title carries pane_id but not workspace_id. Each candidate is
     # confirmed with `pane get`.
     [ -n "${2:-}" ] || return 1
-    "$1" pane list 2>/dev/null |
+    _helper_cands=$("$1" pane list 2>/dev/null |
         tr '{' '\n' |
         grep -F -e "\"label\":\"$3\"" |
-        sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p' |
-        while IFS= read -r _helper_cand; do
-            [ -n "$_helper_cand" ] || continue
-            _helper_cand_ws=$(helper_lantern_pane_workspace "$1" "$_helper_cand" "$3") ||
-                continue
-            if [ "$_helper_cand_ws" = "$2" ]; then
-                printf '%s' "$_helper_cand"
-                return 0
-            fi
-        done
+        sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p') || return 1
+    # Pane ids hold no spaces, so a plain word loop keeps this out of a
+    # subshell and lets the function fail when it finds nothing.
+    for _helper_cand in $_helper_cands; do
+        _helper_cand_ws=$(helper_lantern_pane_workspace "$1" "$_helper_cand" "$3") ||
+            continue
+        if [ "$_helper_cand_ws" = "$2" ]; then
+            printf '%s' "$_helper_cand"
+            return 0
+        fi
+    done
+    return 1
 }
 
 helper_resolve_real_herdr() {

--- a/lib.sh
+++ b/lib.sh
@@ -224,6 +224,29 @@ helper_lantern_pane_workspace() {
     printf '%s' "$_helper_pane_json" | helper_json_value workspace_id
 }
 
+helper_lantern_pane_in_workspace() {
+    # $1 real herdr, $2 workspace id, $3 pane title. Prints a live lantern
+    # chat already sitting in that workspace. Herdr does not deduplicate
+    # plugin panes, so this is what stops a second chat.
+    # `pane list` objects nest `scroll`, so the fragment that carries the
+    # title carries pane_id but not workspace_id. Each candidate is
+    # confirmed with `pane get`.
+    [ -n "${2:-}" ] || return 1
+    "$1" pane list 2>/dev/null |
+        tr '{' '\n' |
+        grep -F -e "\"label\":\"$3\"" |
+        sed -n 's/.*"pane_id":"\([^"]*\)".*/\1/p' |
+        while IFS= read -r _helper_cand; do
+            [ -n "$_helper_cand" ] || continue
+            _helper_cand_ws=$(helper_lantern_pane_workspace "$1" "$_helper_cand" "$3") ||
+                continue
+            if [ "$_helper_cand_ws" = "$2" ]; then
+                printf '%s' "$_helper_cand"
+                return 0
+            fi
+        done
+}
+
 helper_resolve_real_herdr() {
     if [ -n "${HERDR_REAL:-}" ] && [ -x "$HERDR_REAL" ]; then
         printf '%s' "$HERDR_REAL"

--- a/open.sh
+++ b/open.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # Action entrypoint: light the lantern in its own workspace.
 #
-# First open: create a workspace labelled "lantern" with --cwd $HOME and
-# seat the lantern chat there as a tab, then drop the empty shell tab the
-# new workspace came with. Later opens: focus that same workspace and the
-# chat already in it. Herdr appends a new workspace at the end of the
-# sidebar; there is no pin-to-top, so drag it where you want it.
+# First open: create a workspace labelled "🏮 lantern" with --cwd $HOME and
+# seat the lantern chat there as a tab named "field", then drop the empty
+# shell tab the new workspace came with. Later opens: focus that same
+# workspace and the chat already in it. Herdr appends a new workspace at the
+# end of the sidebar; there is no pin-to-top, so drag it where you want it.
 #
 # Bind a key to aigora.lantern.open to reach this from anywhere.
 set -eu
@@ -14,9 +14,13 @@ plugin_root=${HERDR_PLUGIN_ROOT:-$(CDPATH= cd -- "$(dirname "$0")" && pwd)}
 # shellcheck disable=SC1091
 . "$plugin_root/lib.sh"
 
-# Workspace label and pane title. The title must match [[panes]].title in
-# herdr-plugin.toml; open.sh uses it to recognise a live lantern chat.
-workspace_label=lantern
+# Sidebar naming. The workspace carries the lantern; the tab is the chat.
+# pane_title must match [[panes]].title in herdr-plugin.toml, because
+# open.sh uses it to recognise a live lantern chat. legacy_label keeps
+# workspaces labelled by hand, or by an earlier version, in use.
+workspace_label='🏮 lantern'
+legacy_label=lantern
+tab_label=field
 pane_title=Lantern
 
 die() {
@@ -40,6 +44,10 @@ if [ -f "$workspace_file" ]; then
 fi
 if [ -z "$workspace" ]; then
     workspace=$(helper_workspace_id_by_label "$herdr" "$workspace_label") ||
+        workspace=
+fi
+if [ -z "$workspace" ]; then
+    workspace=$(helper_workspace_id_by_label "$herdr" "$legacy_label") ||
         workspace=
 fi
 
@@ -81,7 +89,7 @@ if [ -n "$pane" ]; then
     printf '%s\n' "$pane" >"$pane_file" || true
 fi
 if [ -n "$tab" ]; then
-    "$herdr" tab rename "$tab" "$pane_title" >/dev/null 2>&1 || true
+    "$herdr" tab rename "$tab" "$tab_label" >/dev/null 2>&1 || true
 fi
 
 # 5. A fresh workspace opens with an empty shell tab. The chat replaces it.

--- a/open.sh
+++ b/open.sh
@@ -1,8 +1,93 @@
 #!/bin/sh
-# Action entrypoint: open the lantern. Bind a key to
-# aigora.lantern.open to reach this from anywhere.
+# Action entrypoint: light the lantern in its own workspace.
+#
+# First open: create a workspace labelled "lantern" with --cwd $HOME and
+# seat the lantern chat there as a tab, then drop the empty shell tab the
+# new workspace came with. Later opens: focus that same workspace and the
+# chat already in it. Herdr appends a new workspace at the end of the
+# sidebar; there is no pin-to-top, so drag it where you want it.
+#
+# Bind a key to aigora.lantern.open to reach this from anywhere.
 set -eu
 
-exec "${HERDR_BIN_PATH:-herdr}" plugin pane open \
+plugin_root=${HERDR_PLUGIN_ROOT:-$(CDPATH= cd -- "$(dirname "$0")" && pwd)}
+# shellcheck disable=SC1091
+. "$plugin_root/lib.sh"
+
+# Workspace label and pane title. The title must match [[panes]].title in
+# herdr-plugin.toml; open.sh uses it to recognise a live lantern chat.
+workspace_label=lantern
+pane_title=Lantern
+
+die() {
+    printf 'lantern: %s\n' "$1" >&2
+    exit 1
+}
+
+herdr=$(helper_resolve_real_herdr "$plugin_root/bin") ||
+    die "could not find the herdr binary"
+
+state_dir=${HERDR_PLUGIN_STATE_DIR:-${HERDR_PLUGIN_CONFIG_DIR:-$plugin_root}/state}
+mkdir -p "$state_dir" || die "could not create $state_dir"
+workspace_file=$state_dir/workspace.id
+pane_file=$state_dir/pane.id
+
+# 1. Find the lantern workspace: remembered id first, then the label.
+workspace=
+if [ -f "$workspace_file" ]; then
+    workspace=$(cat "$workspace_file") || workspace=
+    helper_workspace_exists "$herdr" "$workspace" || workspace=
+fi
+if [ -z "$workspace" ]; then
+    workspace=$(helper_workspace_id_by_label "$herdr" "$workspace_label") ||
+        workspace=
+fi
+
+# 2. No lantern workspace yet: make one at home.
+root_pane=
+if [ -z "$workspace" ]; then
+    created=$("$herdr" workspace create --cwd "$HOME" \
+        --label "$workspace_label" --no-focus) ||
+        die "could not create the $workspace_label workspace"
+    workspace=$(printf '%s' "$created" | helper_json_value workspace_id)
+    [ -n "$workspace" ] || die "could not read the new workspace id"
+    root_pane=$(printf '%s' "$created" | helper_json_value pane_id)
+fi
+printf '%s\n' "$workspace" >"$workspace_file" || true
+
+# 3. A live lantern chat in that workspace is the one to focus.
+pane=
+if [ -f "$pane_file" ]; then
+    pane=$(cat "$pane_file") || pane=
+    helper_pane_is_lantern "$herdr" "$pane" "$workspace" "$pane_title" ||
+        pane=
+fi
+if [ -n "$pane" ]; then
+    "$herdr" workspace focus "$workspace" >/dev/null 2>&1 || true
+    exec "$herdr" plugin pane focus "$pane"
+fi
+
+# 4. Seat a new lantern chat as a tab in that workspace.
+opened=$("$herdr" plugin pane open \
     --plugin aigora.lantern \
-    --entrypoint helper
+    --entrypoint helper \
+    --placement tab \
+    --workspace "$workspace" \
+    --focus) || die "could not open the lantern chat in $workspace"
+
+pane=$(printf '%s' "$opened" | helper_json_value pane_id)
+tab=$(printf '%s' "$opened" | helper_json_value tab_id)
+if [ -n "$pane" ]; then
+    printf '%s\n' "$pane" >"$pane_file" || true
+fi
+if [ -n "$tab" ]; then
+    "$herdr" tab rename "$tab" "$pane_title" >/dev/null 2>&1 || true
+fi
+
+# 5. A fresh workspace opens with an empty shell tab. The chat replaces it.
+if [ -n "$root_pane" ]; then
+    "$herdr" pane close "$root_pane" >/dev/null 2>&1 || true
+fi
+
+"$herdr" workspace focus "$workspace" >/dev/null 2>&1 || true
+printf '%s\n' "$opened"

--- a/open.sh
+++ b/open.sh
@@ -69,9 +69,9 @@ if [ -n "$workspace" ]; then
         printf '%s\n' "$workspace" >"$workspace_file" || true
         exit 0
     fi
-    # The chat quit between the check and the focus. Seat a new one.
+    # The chat quit between the check and the focus. Seat a new one, and
+    # keep the id so step 5 does not offer the same dead pane again.
     workspace=
-    pane=
 fi
 
 # 2. No live chat. The remembered workspace counts only while it still
@@ -110,12 +110,14 @@ fi
 if [ -z "$root_pane" ]; then
     running=$(helper_lantern_pane_in_workspace "$herdr" "$workspace" "$pane_title") ||
         running=
-    if [ -n "$running" ]; then
+    if [ -n "$running" ] && [ "$running" != "$pane" ]; then
         printf '%s\n' "$workspace" >"$workspace_file" || true
         printf '%s\n' "$running" >"$pane_file" || true
         "$herdr" workspace focus "$workspace" >/dev/null 2>&1 || true
-        "$herdr" plugin pane focus "$running"
-        exit 0
+        if "$herdr" plugin pane focus "$running"; then
+            exit 0
+        fi
+        # It went away too. Seat a new one below.
     fi
 fi
 

--- a/open.sh
+++ b/open.sh
@@ -39,10 +39,13 @@ lock_dir=$state_dir/open.lock
 
 # One open at a time. Two fast key presses must not make two workspaces.
 if ! mkdir "$lock_dir" 2>/dev/null; then
+    [ -d "$lock_dir" ] || die "could not lock $state_dir"
     if [ -n "$(find "$lock_dir" -prune -mmin +2 2>/dev/null)" ]; then
+        # Left behind by a kill or a crash.
         rmdir "$lock_dir" 2>/dev/null || true
-        mkdir "$lock_dir" 2>/dev/null || exit 0
+        mkdir "$lock_dir" 2>/dev/null || die "could not lock $state_dir"
     else
+        printf 'lantern: another open is in flight\n' >&2
         exit 0
     fi
 fi
@@ -61,10 +64,14 @@ if [ -n "$pane" ]; then
         workspace=
 fi
 if [ -n "$workspace" ]; then
-    printf '%s\n' "$workspace" >"$workspace_file" || true
     "$herdr" workspace focus "$workspace" >/dev/null 2>&1 || true
-    "$herdr" plugin pane focus "$pane"
-    exit 0
+    if "$herdr" plugin pane focus "$pane"; then
+        printf '%s\n' "$workspace" >"$workspace_file" || true
+        exit 0
+    fi
+    # The chat quit between the check and the focus. Seat a new one.
+    workspace=
+    pane=
 fi
 
 # 2. No live chat. The remembered workspace counts only while it still
@@ -98,7 +105,21 @@ if [ -z "$workspace" ]; then
     root_pane=$(printf '%s' "$created" | helper_json_value pane_id)
 fi
 
-# 5. Seat the chat as a tab in that workspace.
+# 5. A workspace we did not just make can already hold a chat, if the
+#    remembered pane id was lost. Herdr would open a second one.
+if [ -z "$root_pane" ]; then
+    running=$(helper_lantern_pane_in_workspace "$herdr" "$workspace" "$pane_title") ||
+        running=
+    if [ -n "$running" ]; then
+        printf '%s\n' "$workspace" >"$workspace_file" || true
+        printf '%s\n' "$running" >"$pane_file" || true
+        "$herdr" workspace focus "$workspace" >/dev/null 2>&1 || true
+        "$herdr" plugin pane focus "$running"
+        exit 0
+    fi
+fi
+
+# 6. Seat the chat as a tab in that workspace.
 if ! opened=$("$herdr" plugin pane open \
     --plugin aigora.lantern \
     --entrypoint helper \
@@ -135,7 +156,7 @@ if [ -n "$tab" ]; then
     "$herdr" tab rename "$tab" "$tab_label" >/dev/null 2>&1 || true
 fi
 
-# 6. A fresh workspace opens with an empty shell tab. The chat replaces it.
+# 7. A fresh workspace opens with an empty shell tab. The chat replaces it.
 if [ -n "$root_pane" ]; then
     "$herdr" pane close "$root_pane" >/dev/null 2>&1 || true
 fi

--- a/open.sh
+++ b/open.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 # Action entrypoint: light the lantern in its own workspace.
 #
-# First open: create a workspace labelled "🏮 lantern" with --cwd $HOME and
+# First open: create a workspace labelled "🪔 lantern" with --cwd $HOME and
 # seat the lantern chat there as a tab named "field", then drop the empty
-# shell tab the new workspace came with. Later opens: focus that same
-# workspace and the chat already in it. Herdr appends a new workspace at the
-# end of the sidebar; there is no pin-to-top, so drag it where you want it.
+# shell tab the new workspace came with. Later opens: focus the chat that
+# is already running, or seat a new one in that same workspace. Herdr
+# appends a new workspace at the end of the sidebar; there is no
+# pin-to-top, so drag it where you want it.
 #
 # Bind a key to aigora.lantern.open to reach this from anywhere.
 set -eu
@@ -16,10 +17,8 @@ plugin_root=${HERDR_PLUGIN_ROOT:-$(CDPATH= cd -- "$(dirname "$0")" && pwd)}
 
 # Sidebar naming. The workspace carries the lantern; the tab is the chat.
 # pane_title must match [[panes]].title in herdr-plugin.toml, because
-# open.sh uses it to recognise a live lantern chat. legacy_label keeps
-# workspaces labelled by hand, or by an earlier version, in use.
-workspace_label='🏮 lantern'
-legacy_label=lantern
+# open.sh uses it to recognise a live lantern chat.
+workspace_label='🪔 lantern'
 tab_label=field
 pane_title=Lantern
 
@@ -30,61 +29,105 @@ die() {
 
 herdr=$(helper_resolve_real_herdr "$plugin_root/bin") ||
     die "could not find the herdr binary"
+[ -n "${HOME:-}" ] || die "HOME is not set"
 
 state_dir=${HERDR_PLUGIN_STATE_DIR:-${HERDR_PLUGIN_CONFIG_DIR:-$plugin_root}/state}
 mkdir -p "$state_dir" || die "could not create $state_dir"
 workspace_file=$state_dir/workspace.id
 pane_file=$state_dir/pane.id
+lock_dir=$state_dir/open.lock
 
-# 1. Find the lantern workspace: remembered id first, then the label.
+# One open at a time. Two fast key presses must not make two workspaces.
+if ! mkdir "$lock_dir" 2>/dev/null; then
+    if [ -n "$(find "$lock_dir" -prune -mmin +2 2>/dev/null)" ]; then
+        rmdir "$lock_dir" 2>/dev/null || true
+        mkdir "$lock_dir" 2>/dev/null || exit 0
+    else
+        exit 0
+    fi
+fi
+trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
+trap 'rmdir "$lock_dir" 2>/dev/null || true; exit 1' INT TERM HUP
+
+# 1. A chat that is still running is the answer, wherever it sits now.
+#    It names its own workspace, so moving or renaming the tab is safe.
+pane=
+if [ -f "$pane_file" ]; then
+    pane=$(cat "$pane_file") || pane=
+fi
+workspace=
+if [ -n "$pane" ]; then
+    workspace=$(helper_lantern_pane_workspace "$herdr" "$pane" "$pane_title") ||
+        workspace=
+fi
+if [ -n "$workspace" ]; then
+    printf '%s\n' "$workspace" >"$workspace_file" || true
+    "$herdr" workspace focus "$workspace" >/dev/null 2>&1 || true
+    "$herdr" plugin pane focus "$pane"
+    exit 0
+fi
+
+# 2. No live chat. The remembered workspace counts only while it still
+#    carries the lantern label: Herdr reuses ids after a restart, and a
+#    stale id would seat the chat in somebody else's workspace.
 workspace=
 if [ -f "$workspace_file" ]; then
-    workspace=$(cat "$workspace_file") || workspace=
-    helper_workspace_exists "$herdr" "$workspace" || workspace=
+    remembered=$(cat "$workspace_file") || remembered=
+    if [ -n "$remembered" ]; then
+        label=$(helper_workspace_label "$herdr" "$remembered") || label=
+        if [ "$label" = "$workspace_label" ]; then
+            workspace=$remembered
+        fi
+    fi
 fi
+
+# 3. Then the label itself.
 if [ -z "$workspace" ]; then
     workspace=$(helper_workspace_id_by_label "$herdr" "$workspace_label") ||
         workspace=
 fi
-if [ -z "$workspace" ]; then
-    workspace=$(helper_workspace_id_by_label "$herdr" "$legacy_label") ||
-        workspace=
-fi
 
-# 2. No lantern workspace yet: make one at home.
+# 4. Still nothing: make the lantern its own workspace, at home.
 root_pane=
 if [ -z "$workspace" ]; then
     created=$("$herdr" workspace create --cwd "$HOME" \
         --label "$workspace_label" --no-focus) ||
-        die "could not create the $workspace_label workspace"
+        die "could not create the lantern workspace"
     workspace=$(printf '%s' "$created" | helper_json_value workspace_id)
     [ -n "$workspace" ] || die "could not read the new workspace id"
     root_pane=$(printf '%s' "$created" | helper_json_value pane_id)
 fi
-printf '%s\n' "$workspace" >"$workspace_file" || true
 
-# 3. A live lantern chat in that workspace is the one to focus.
-pane=
-if [ -f "$pane_file" ]; then
-    pane=$(cat "$pane_file") || pane=
-    helper_pane_is_lantern "$herdr" "$pane" "$workspace" "$pane_title" ||
-        pane=
-fi
-if [ -n "$pane" ]; then
-    "$herdr" workspace focus "$workspace" >/dev/null 2>&1 || true
-    exec "$herdr" plugin pane focus "$pane"
-fi
-
-# 4. Seat a new lantern chat as a tab in that workspace.
-opened=$("$herdr" plugin pane open \
+# 5. Seat the chat as a tab in that workspace.
+if ! opened=$("$herdr" plugin pane open \
     --plugin aigora.lantern \
     --entrypoint helper \
     --placement tab \
     --workspace "$workspace" \
-    --focus) || die "could not open the lantern chat in $workspace"
+    --focus); then
+    # Leave no empty workspace behind when the chat never started.
+    if [ -n "$root_pane" ]; then
+        "$herdr" workspace close "$workspace" >/dev/null 2>&1 || true
+        rm -f "$workspace_file"
+    fi
+    die "could not open the lantern chat in $workspace"
+fi
 
 pane=$(printf '%s' "$opened" | helper_json_value pane_id)
 tab=$(printf '%s' "$opened" | helper_json_value tab_id)
+seated=$(printf '%s' "$opened" | helper_json_value workspace_id)
+
+# Herdr honours --workspace. If that ever changes, follow the chat and
+# drop the workspace this run created, rather than closing a pane in it.
+if [ -n "$seated" ] && [ "$seated" != "$workspace" ]; then
+    if [ -n "$root_pane" ]; then
+        "$herdr" workspace close "$workspace" >/dev/null 2>&1 || true
+        root_pane=
+    fi
+    workspace=$seated
+fi
+
+printf '%s\n' "$workspace" >"$workspace_file" || true
 if [ -n "$pane" ]; then
     printf '%s\n' "$pane" >"$pane_file" || true
 fi
@@ -92,7 +135,7 @@ if [ -n "$tab" ]; then
     "$herdr" tab rename "$tab" "$tab_label" >/dev/null 2>&1 || true
 fi
 
-# 5. A fresh workspace opens with an empty shell tab. The chat replaces it.
+# 6. A fresh workspace opens with an empty shell tab. The chat replaces it.
 if [ -n "$root_pane" ]; then
     "$herdr" pane close "$root_pane" >/dev/null 2>&1 || true
 fi

--- a/prompt.md
+++ b/prompt.md
@@ -57,6 +57,9 @@ beyond this list.
 Ground rules:
 
 - You are the light, not an elf. Do not edit files or do the agent's work.
+- You sit in a tab in the workspace labelled `lantern`. Seat new agents in
+  their own repository workspace, never in this one, and never close this
+  workspace or tab.
 - Never close workspaces, kill panes, or remove worktrees unless they
   name what to close. "Clean up" / "I'm done" is not enough; ask first.
 - Keep answers short. This is a lamp, not a report.

--- a/prompt.md
+++ b/prompt.md
@@ -57,9 +57,10 @@ beyond this list.
 Ground rules:
 
 - You are the light, not an elf. Do not edit files or do the agent's work.
-- You sit in the `field` tab of the workspace labelled `🏮 lantern`. Seat
-  new agents in their own repository workspace, never in this one, and
-  never close this workspace or tab.
+- You sit in the `field` tab of the lantern's own workspace (labelled
+  `🪔 lantern` unless the user renamed it). Seat new agents in their own
+  repository workspace, never in this one, and never close this workspace
+  or tab.
 - Never close workspaces, kill panes, or remove worktrees unless they
   name what to close. "Clean up" / "I'm done" is not enough; ask first.
 - Keep answers short. This is a lamp, not a report.

--- a/prompt.md
+++ b/prompt.md
@@ -57,9 +57,9 @@ beyond this list.
 Ground rules:
 
 - You are the light, not an elf. Do not edit files or do the agent's work.
-- You sit in a tab in the workspace labelled `lantern`. Seat new agents in
-  their own repository workspace, never in this one, and never close this
-  workspace or tab.
+- You sit in the `field` tab of the workspace labelled `🏮 lantern`. Seat
+  new agents in their own repository workspace, never in this one, and
+  never close this workspace or tab.
 - Never close workspaces, kill panes, or remove worktrees unless they
   name what to close. "Clean up" / "I'm done" is not enough; ask first.
 - Keep answers short. This is a lamp, not a report.

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -141,6 +141,9 @@ case "$1 $2" in
     printf '{"result":{"root_pane":{"pane_id":"w9:p1","scroll":{"viewport_rows":32},"tab_id":"w9:t1","workspace_id":"w9"},"workspace":{"label":"new","workspace_id":"w9"}}}\n'
     ;;
 "plugin pane")
+    if [ "$3" = focus ]; then
+        [ "${STUB_FOCUS_FAIL:-}" = 1 ] && exit 1
+    fi
     if [ "$3" = open ]; then
         [ "${STUB_OPEN_FAIL:-}" = 1 ] && exit 1
         printf '{"result":{"plugin_pane":{"pane":{"label":"Lantern","pane_id":"%s:p2","scroll":{"viewport_rows":32},"tab_id":"%s:t2","workspace_id":"%s"}}}}\n' \
@@ -153,7 +156,8 @@ EOF
 chmod +x "$open_dir/herdr"
 STUB_LOG=$open_dir/calls.txt
 export STUB_LOG STUB_WS_EXTRA STUB_WS STUB_WS_LABEL STUB_PANE STUB_PANE_LABEL
-export STUB_OPEN_WS STUB_OPEN_FAIL STUB_PANE_EXTRA
+export STUB_OPEN_WS STUB_OPEN_FAIL STUB_PANE_EXTRA STUB_FOCUS_FAIL
+STUB_FOCUS_FAIL=
 STUB_WS_EXTRA=
 STUB_WS=
 STUB_WS_LABEL=
@@ -224,6 +228,26 @@ logged '--placement tab --workspace w7' || fail "label match should seat in w7"
 if logged 'pane close'; then fail "label match must not close a pane"; fi
 STUB_WS_EXTRA=
 STUB_OPEN_WS=w9
+
+# A chat that dies between the check and the focus is replaced, not fatal.
+reset_open
+printf 'w7\n' >"$open_state/workspace.id"
+printf 'w7:p2\n' >"$open_state/pane.id"
+STUB_PANE=w7:p2
+STUB_FOCUS_FAIL=1
+run_open || fail "a refused focus should not end the open"
+logged 'workspace create --cwd' || fail "a refused focus should seat a new chat"
+STUB_FOCUS_FAIL=
+STUB_PANE=
+
+# A state directory that cannot be locked is an error, not silence.
+reset_open
+chmod 500 "$open_state"
+if run_open; then
+    chmod 700 "$open_state"
+    fail "an unlockable state dir should exit nonzero"
+fi
+chmod 700 "$open_state"
 
 # A workspace labelled by hand is not the lantern workspace.
 reset_open

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -20,7 +20,9 @@ tmp=$(mktemp)
 err=$(mktemp)
 fake=
 fake_prompt=
-trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"' EXIT
+fake_ws=
+open_dir=
+trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$open_dir" ] && rm -rf "$open_dir"' EXIT
 
 printf '%s\n' 'HELPER_AGENT="devin"' 'HELPER_SPAWN_KIND="claude"' >"$tmp"
 HELPER_AGENT=""
@@ -49,55 +51,193 @@ if grep -qE '^(width|height) =' "$root/herdr-plugin.toml"; then
     fail "pane still sizes a popup"
 fi
 
-ws=$(printf '%s' '{"result":{"root_pane":{"pane_id":"w9:p1","tab_id":"w9:t1"},"workspace":{"label":"lantern","workspace_id":"w9"}}}' |
-    helper_json_value workspace_id)
+# Real herdr 0.7.5 shapes, trimmed of fields these helpers ignore.
+created_json='{"id":"cli:workspace:create","result":{"root_pane":{"agent_status":"unknown","cwd":"/Users/j","pane_id":"w9:p1","scroll":{"viewport_rows":32},"tab_id":"w9:t1","workspace_id":"w9"},"tab":{"label":"1","tab_id":"w9:t1","workspace_id":"w9"},"type":"workspace_created","workspace":{"active_tab_id":"w9:t1","label":"🪔 lantern","workspace_id":"w9"}}}'
+opened_json='{"id":"cli:plugin","result":{"plugin_pane":{"entrypoint":"helper","pane":{"agent_status":"unknown","cwd":"/state/workdir","label":"Lantern","pane_id":"w9:p2","scroll":{"viewport_rows":32},"tab_id":"w9:t2","terminal_id":"term_x","workspace_id":"w9"},"plugin_id":"aigora.lantern"},"type":"plugin_pane_opened"}}'
+
+ws=$(printf '%s' "$created_json" | helper_json_value workspace_id)
 [ "$ws" = w9 ] || fail "json workspace_id ($ws)"
-pane=$(printf '%s' '{"result":{"root_pane":{"pane_id":"w9:p1"},"tab":{"tab_id":"w9:t1"}}}' |
-    helper_json_value pane_id)
-[ "$pane" = "w9:p1" ] || fail "json pane_id ($pane)"
+pane=$(printf '%s' "$created_json" | helper_json_value pane_id)
+[ "$pane" = "w9:p1" ] || fail "json root pane_id ($pane)"
+pane=$(printf '%s' "$opened_json" | helper_json_value pane_id)
+[ "$pane" = "w9:p2" ] || fail "json opened pane_id ($pane)"
+tab=$(printf '%s' "$opened_json" | helper_json_value tab_id)
+[ "$tab" = "w9:t2" ] || fail "json opened tab_id ($tab)"
 missing=$(printf '%s' '{"result":{}}' | helper_json_value pane_id)
 [ -z "$missing" ] || fail "json missing key should be empty"
+
+# The chat is found by pane title, so open.sh and the manifest must agree.
+grep -q 'pane_title=Lantern' "$root/open.sh" || fail "open.sh pane title"
+grep -q '^title = "Lantern"$' "$root/herdr-plugin.toml" || fail "manifest pane title"
+grep -q "workspace_label='🪔 lantern'" "$root/open.sh" || fail "open.sh lantern label"
 
 fake_ws=$(mktemp -d)
 cat >"$fake_ws/herdr" <<'EOF'
 #!/bin/sh
 if [ "$1" = workspace ] && [ "$2" = list ]; then
-    printf '%s\n' '{"result":{"workspaces":[{"label":"love-spark","workspace_id":"w1"},{"label":"lantern","workspace_id":"w5"},{"label":"🏮 lantern","workspace_id":"w7"}]}}'
+    printf '%s\n' '{"result":{"workspaces":[{"label":"love-spark","workspace_id":"w1"},{"label":"lantern","workspace_id":"w5"},{"label":"🪔 lantern","workspace_id":"w7"}]}}'
     exit 0
 fi
 if [ "$1" = workspace ] && [ "$2" = get ]; then
-    [ "$3" = w7 ] && exit 0
-    exit 1
+    [ "$3" = w7 ] || exit 1
+    printf '%s\n' '{"result":{"type":"workspace_info","workspace":{"active_tab_id":"w7:t2","label":"🪔 lantern","workspace_id":"w7"}}}'
+    exit 0
 fi
 if [ "$1" = pane ] && [ "$2" = get ]; then
     [ "$3" = "w7:p2" ] || exit 1
-    printf '%s\n' '{"result":{"pane":{"label":"Lantern","pane_id":"w7:p2","workspace_id":"w7"}}}'
+    printf '%s\n' '{"result":{"pane":{"agent_status":"idle","label":"Lantern","pane_id":"w7:p2","scroll":{"viewport_rows":32},"tab_id":"w7:t2","workspace_id":"w7"},"type":"pane_info"}}'
     exit 0
 fi
 exit 1
 EOF
 chmod +x "$fake_ws/herdr"
-found=$(helper_workspace_id_by_label "$fake_ws/herdr" '🏮 lantern')
+found=$(helper_workspace_id_by_label "$fake_ws/herdr" '🪔 lantern')
 [ "$found" = w7 ] || fail "workspace by lantern label ($found)"
-legacy=$(helper_workspace_id_by_label "$fake_ws/herdr" lantern)
-[ "$legacy" = w5 ] || fail "workspace by legacy label ($legacy)"
 [ -z "$(helper_workspace_id_by_label "$fake_ws/herdr" nope)" ] || fail "unknown label"
-grep -q "workspace_label='🏮 lantern'" "$root/open.sh" || fail "open.sh lantern label"
-grep -q 'legacy_label=lantern' "$root/open.sh" || fail "open.sh legacy label"
-helper_workspace_exists "$fake_ws/herdr" w7 || fail "workspace exists"
-if helper_workspace_exists "$fake_ws/herdr" w8; then fail "stale workspace id"; fi
-if helper_workspace_exists "$fake_ws/herdr" ""; then fail "empty workspace id"; fi
-helper_pane_is_lantern "$fake_ws/herdr" w7:p2 w7 Lantern || fail "lantern pane"
-if helper_pane_is_lantern "$fake_ws/herdr" w7:p2 w9 Lantern; then
-    fail "pane in another workspace"
+[ "$(helper_workspace_label "$fake_ws/herdr" w7)" = '🪔 lantern' ] ||
+    fail "workspace label"
+if helper_workspace_label "$fake_ws/herdr" w8 >/dev/null 2>&1; then
+    fail "stale workspace id"
 fi
-if helper_pane_is_lantern "$fake_ws/herdr" w7:p2 w7 Probe; then
+if helper_workspace_label "$fake_ws/herdr" "" >/dev/null 2>&1; then
+    fail "empty workspace id"
+fi
+[ "$(helper_lantern_pane_workspace "$fake_ws/herdr" w7:p2 Lantern)" = w7 ] ||
+    fail "lantern pane workspace"
+if helper_lantern_pane_workspace "$fake_ws/herdr" w7:p2 Probe >/dev/null 2>&1; then
     fail "pane with another title"
 fi
-if helper_pane_is_lantern "$fake_ws/herdr" w7:p9 w7 Lantern; then
+if helper_lantern_pane_workspace "$fake_ws/herdr" w7:p9 Lantern >/dev/null 2>&1; then
     fail "missing pane"
 fi
-rm -rf "$fake_ws"
+if helper_lantern_pane_workspace "$fake_ws/herdr" "" Lantern >/dev/null 2>&1; then
+    fail "empty pane id"
+fi
+
+# open.sh end to end against a stub herdr that records every call.
+open_dir=$(mktemp -d)
+cat >"$open_dir/herdr" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$STUB_LOG"
+case "$1 $2" in
+"workspace list")
+    printf '{"result":{"workspaces":[{"label":"repo","workspace_id":"w1"}%s]}}\n' "$STUB_WS_EXTRA"
+    ;;
+"workspace get")
+    [ "$3" = "$STUB_WS" ] || exit 1
+    printf '{"result":{"workspace":{"label":"%s","workspace_id":"%s"}}}\n' \
+        "$STUB_WS_LABEL" "$3"
+    ;;
+"pane get")
+    [ "$3" = "$STUB_PANE" ] || exit 1
+    printf '{"result":{"pane":{"label":"%s","pane_id":"%s","scroll":{"viewport_rows":32},"tab_id":"%s:t2","workspace_id":"%s"}}}\n' \
+        "$STUB_PANE_LABEL" "$3" "${3%%:*}" "${3%%:*}"
+    ;;
+"workspace create")
+    printf '{"result":{"root_pane":{"pane_id":"w9:p1","scroll":{"viewport_rows":32},"tab_id":"w9:t1","workspace_id":"w9"},"workspace":{"label":"new","workspace_id":"w9"}}}\n'
+    ;;
+"plugin pane")
+    if [ "$3" = open ]; then
+        [ "${STUB_OPEN_FAIL:-}" = 1 ] && exit 1
+        printf '{"result":{"plugin_pane":{"pane":{"label":"Lantern","pane_id":"%s:p2","scroll":{"viewport_rows":32},"tab_id":"%s:t2","workspace_id":"%s"}}}}\n' \
+            "$STUB_OPEN_WS" "$STUB_OPEN_WS" "$STUB_OPEN_WS"
+    fi
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$open_dir/herdr"
+STUB_LOG=$open_dir/calls.txt
+export STUB_LOG STUB_WS_EXTRA STUB_WS STUB_WS_LABEL STUB_PANE STUB_PANE_LABEL
+export STUB_OPEN_WS STUB_OPEN_FAIL
+STUB_WS_EXTRA=
+STUB_WS=
+STUB_WS_LABEL=
+STUB_PANE=
+STUB_PANE_LABEL=Lantern
+STUB_OPEN_WS=w9
+STUB_OPEN_FAIL=
+
+open_state=$open_dir/state
+reset_open() {
+    rm -rf "$open_state"
+    mkdir -p "$open_state"
+    : >"$STUB_LOG"
+}
+run_open() {
+    HERDR_REAL="$open_dir/herdr" \
+        HERDR_PLUGIN_STATE_DIR="$open_state" \
+        HERDR_PLUGIN_ROOT="$root" \
+        sh "$root/open.sh" >/dev/null 2>&1
+}
+logged() { grep -qF -e "$1" "$STUB_LOG"; }
+
+# First open: create the lantern workspace, seat the chat, drop the shell.
+reset_open
+run_open || fail "first open"
+logged 'workspace create --cwd' || fail "first open should create a workspace"
+logged '--label 🪔 lantern' || fail "first open should use the lantern label"
+logged 'plugin pane open --plugin aigora.lantern --entrypoint helper --placement tab --workspace w9' ||
+    fail "first open should seat a tab in the new workspace"
+logged 'tab rename w9:t2 field' || fail "first open should name the tab"
+logged 'pane close w9:p1' || fail "first open should close the empty shell"
+[ "$(cat "$open_state/workspace.id")" = w9 ] || fail "first open workspace state"
+[ "$(cat "$open_state/pane.id")" = w9:p2 ] || fail "first open pane state"
+
+# A live chat is focused, not opened again, wherever it sits now.
+reset_open
+printf 'w7\n' >"$open_state/workspace.id"
+printf 'w7:p2\n' >"$open_state/pane.id"
+STUB_PANE=w7:p2
+run_open || fail "reopen with a live chat"
+logged 'plugin pane focus w7:p2' || fail "reopen should focus the live chat"
+if logged 'plugin pane open'; then fail "reopen should not seat a second chat"; fi
+if logged 'workspace create'; then fail "reopen should not create a workspace"; fi
+STUB_PANE=
+
+# A remembered id that lost the label is somebody else's workspace now.
+reset_open
+printf 'w1\n' >"$open_state/workspace.id"
+STUB_WS=w1
+STUB_WS_LABEL=repo
+STUB_OPEN_WS=w9
+run_open || fail "stale workspace id"
+if logged 'plugin pane open --plugin aigora.lantern --entrypoint helper --placement tab --workspace w1'; then
+    fail "a relabelled workspace must not host the chat"
+fi
+logged 'workspace create --cwd' || fail "stale id should fall through to create"
+STUB_WS=
+STUB_WS_LABEL=
+
+# An existing lantern workspace is reused, and no shell tab is closed.
+reset_open
+STUB_WS_EXTRA=',{"label":"🪔 lantern","workspace_id":"w7"}'
+STUB_OPEN_WS=w7
+run_open || fail "reuse by label"
+if logged 'workspace create'; then fail "label match must not create a workspace"; fi
+logged '--placement tab --workspace w7' || fail "label match should seat in w7"
+if logged 'pane close'; then fail "label match must not close a pane"; fi
+STUB_WS_EXTRA=
+STUB_OPEN_WS=w9
+
+# A chat that never starts must not leave an empty workspace behind.
+reset_open
+STUB_OPEN_FAIL=1
+if run_open; then fail "failed open should exit nonzero"; fi
+logged 'workspace close w9' || fail "failed open should drop the new workspace"
+if [ -f "$open_state/workspace.id" ]; then
+    fail "failed open should not remember a workspace"
+fi
+STUB_OPEN_FAIL=
+
+# A second open while one is in flight does nothing.
+reset_open
+mkdir "$open_state/open.lock"
+run_open || fail "locked open should exit 0"
+if [ -s "$STUB_LOG" ]; then
+    fail "locked open should call nothing"
+fi
+rmdir "$open_state/open.lock"
 
 detected=$(helper_detect_agent) || fail "no helper agent on PATH"
 case $detected in

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -44,6 +44,57 @@ fi
 [ "$(helper_normalize_root "$HOME/")" = "$HOME" ] || fail "normalize HOME/"
 grep -q 'CLAUDE.md' "$root/launch.sh" || fail "launch writes CLAUDE.md"
 
+grep -q '^placement = "tab"$' "$root/herdr-plugin.toml" || fail "pane placement is tab"
+if grep -qE '^(width|height) =' "$root/herdr-plugin.toml"; then
+    fail "pane still sizes a popup"
+fi
+
+ws=$(printf '%s' '{"result":{"root_pane":{"pane_id":"w9:p1","tab_id":"w9:t1"},"workspace":{"label":"lantern","workspace_id":"w9"}}}' |
+    helper_json_value workspace_id)
+[ "$ws" = w9 ] || fail "json workspace_id ($ws)"
+pane=$(printf '%s' '{"result":{"root_pane":{"pane_id":"w9:p1"},"tab":{"tab_id":"w9:t1"}}}' |
+    helper_json_value pane_id)
+[ "$pane" = "w9:p1" ] || fail "json pane_id ($pane)"
+missing=$(printf '%s' '{"result":{}}' | helper_json_value pane_id)
+[ -z "$missing" ] || fail "json missing key should be empty"
+
+fake_ws=$(mktemp -d)
+cat >"$fake_ws/herdr" <<'EOF'
+#!/bin/sh
+if [ "$1" = workspace ] && [ "$2" = list ]; then
+    printf '%s\n' '{"result":{"workspaces":[{"label":"love-spark","workspace_id":"w1"},{"label":"lantern","workspace_id":"w7"}]}}'
+    exit 0
+fi
+if [ "$1" = workspace ] && [ "$2" = get ]; then
+    [ "$3" = w7 ] && exit 0
+    exit 1
+fi
+if [ "$1" = pane ] && [ "$2" = get ]; then
+    [ "$3" = "w7:p2" ] || exit 1
+    printf '%s\n' '{"result":{"pane":{"label":"Lantern","pane_id":"w7:p2","workspace_id":"w7"}}}'
+    exit 0
+fi
+exit 1
+EOF
+chmod +x "$fake_ws/herdr"
+found=$(helper_workspace_id_by_label "$fake_ws/herdr" lantern)
+[ "$found" = w7 ] || fail "workspace by label ($found)"
+[ -z "$(helper_workspace_id_by_label "$fake_ws/herdr" nope)" ] || fail "unknown label"
+helper_workspace_exists "$fake_ws/herdr" w7 || fail "workspace exists"
+if helper_workspace_exists "$fake_ws/herdr" w8; then fail "stale workspace id"; fi
+if helper_workspace_exists "$fake_ws/herdr" ""; then fail "empty workspace id"; fi
+helper_pane_is_lantern "$fake_ws/herdr" w7:p2 w7 Lantern || fail "lantern pane"
+if helper_pane_is_lantern "$fake_ws/herdr" w7:p2 w9 Lantern; then
+    fail "pane in another workspace"
+fi
+if helper_pane_is_lantern "$fake_ws/herdr" w7:p2 w7 Probe; then
+    fail "pane with another title"
+fi
+if helper_pane_is_lantern "$fake_ws/herdr" w7:p9 w7 Lantern; then
+    fail "missing pane"
+fi
+rm -rf "$fake_ws"
+
 detected=$(helper_detect_agent) || fail "no helper agent on PATH"
 case $detected in
 devin | agent | claude | codex | grok) ;;

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -62,7 +62,7 @@ fake_ws=$(mktemp -d)
 cat >"$fake_ws/herdr" <<'EOF'
 #!/bin/sh
 if [ "$1" = workspace ] && [ "$2" = list ]; then
-    printf '%s\n' '{"result":{"workspaces":[{"label":"love-spark","workspace_id":"w1"},{"label":"lantern","workspace_id":"w7"}]}}'
+    printf '%s\n' '{"result":{"workspaces":[{"label":"love-spark","workspace_id":"w1"},{"label":"lantern","workspace_id":"w5"},{"label":"🏮 lantern","workspace_id":"w7"}]}}'
     exit 0
 fi
 if [ "$1" = workspace ] && [ "$2" = get ]; then
@@ -77,9 +77,13 @@ fi
 exit 1
 EOF
 chmod +x "$fake_ws/herdr"
-found=$(helper_workspace_id_by_label "$fake_ws/herdr" lantern)
-[ "$found" = w7 ] || fail "workspace by label ($found)"
+found=$(helper_workspace_id_by_label "$fake_ws/herdr" '🏮 lantern')
+[ "$found" = w7 ] || fail "workspace by lantern label ($found)"
+legacy=$(helper_workspace_id_by_label "$fake_ws/herdr" lantern)
+[ "$legacy" = w5 ] || fail "workspace by legacy label ($legacy)"
 [ -z "$(helper_workspace_id_by_label "$fake_ws/herdr" nope)" ] || fail "unknown label"
+grep -q "workspace_label='🏮 lantern'" "$root/open.sh" || fail "open.sh lantern label"
+grep -q 'legacy_label=lantern' "$root/open.sh" || fail "open.sh legacy label"
 helper_workspace_exists "$fake_ws/herdr" w7 || fail "workspace exists"
 if helper_workspace_exists "$fake_ws/herdr" w8; then fail "stale workspace id"; fi
 if helper_workspace_exists "$fake_ws/herdr" ""; then fail "empty workspace id"; fi

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -133,6 +133,10 @@ case "$1 $2" in
     printf '{"result":{"pane":{"label":"%s","pane_id":"%s","scroll":{"viewport_rows":32},"tab_id":"%s:t2","workspace_id":"%s"}}}\n' \
         "$STUB_PANE_LABEL" "$3" "${3%%:*}" "${3%%:*}"
     ;;
+"pane list")
+    printf '{"result":{"panes":[{"agent_status":"idle","cwd":"/repo","pane_id":"w1:p1","scroll":{"viewport_rows":32},"tab_id":"w1:t1","workspace_id":"w1"}%s]}}\n' \
+        "$STUB_PANE_EXTRA"
+    ;;
 "workspace create")
     printf '{"result":{"root_pane":{"pane_id":"w9:p1","scroll":{"viewport_rows":32},"tab_id":"w9:t1","workspace_id":"w9"},"workspace":{"label":"new","workspace_id":"w9"}}}\n'
     ;;
@@ -149,12 +153,13 @@ EOF
 chmod +x "$open_dir/herdr"
 STUB_LOG=$open_dir/calls.txt
 export STUB_LOG STUB_WS_EXTRA STUB_WS STUB_WS_LABEL STUB_PANE STUB_PANE_LABEL
-export STUB_OPEN_WS STUB_OPEN_FAIL
+export STUB_OPEN_WS STUB_OPEN_FAIL STUB_PANE_EXTRA
 STUB_WS_EXTRA=
 STUB_WS=
 STUB_WS_LABEL=
 STUB_PANE=
 STUB_PANE_LABEL=Lantern
+STUB_PANE_EXTRA=
 STUB_OPEN_WS=w9
 STUB_OPEN_FAIL=
 
@@ -220,15 +225,50 @@ if logged 'pane close'; then fail "label match must not close a pane"; fi
 STUB_WS_EXTRA=
 STUB_OPEN_WS=w9
 
+# A workspace labelled by hand is not the lantern workspace.
+reset_open
+STUB_WS_EXTRA=',{"label":"lantern","workspace_id":"w5"}'
+run_open || fail "plain label"
+if logged '--workspace w5'; then fail "a plain lantern label must not be adopted"; fi
+logged 'workspace create --cwd' || fail "plain label should fall through to create"
+STUB_WS_EXTRA=
+
+# A chat already running in that workspace is focused, not duplicated.
+reset_open
+STUB_WS_EXTRA=',{"label":"🪔 lantern","workspace_id":"w7"}'
+STUB_PANE_EXTRA=',{"agent_status":"idle","cwd":"/state","label":"Lantern","pane_id":"w7:p2","scroll":{"viewport_rows":32},"tab_id":"w7:t2","workspace_id":"w7"}'
+STUB_PANE=w7:p2
+run_open || fail "duplicate guard"
+logged 'plugin pane focus w7:p2' || fail "an existing chat should be focused"
+if logged 'plugin pane open'; then fail "must not seat a second chat in w7"; fi
+[ "$(cat "$open_state/pane.id")" = w7:p2 ] || fail "duplicate guard pane state"
+STUB_WS_EXTRA=
+STUB_PANE_EXTRA=
+STUB_PANE=
+
+# Follow the workspace Herdr reports, and drop the one this run made.
+reset_open
+STUB_OPEN_WS=w8
+run_open || fail "adopt the reported workspace"
+logged 'workspace close w9' || fail "the unused new workspace should be closed"
+if logged 'pane close w9:p1'; then fail "must not close a pane in a dropped workspace"; fi
+[ "$(cat "$open_state/workspace.id")" = w8 ] || fail "adopted workspace state"
+STUB_OPEN_WS=w9
+
 # A chat that never starts must not leave an empty workspace behind.
 reset_open
+printf 'w1\n' >"$open_state/workspace.id"
+STUB_WS=w1
+STUB_WS_LABEL=repo
 STUB_OPEN_FAIL=1
 if run_open; then fail "failed open should exit nonzero"; fi
 logged 'workspace close w9' || fail "failed open should drop the new workspace"
 if [ -f "$open_state/workspace.id" ]; then
-    fail "failed open should not remember a workspace"
+    fail "failed open should forget the workspace"
 fi
 STUB_OPEN_FAIL=
+STUB_WS=
+STUB_WS_LABEL=
 
 # A second open while one is in flight does nothing.
 reset_open


### PR DESCRIPTION
## What changed

The helper pane was a 90% lightbox over whatever you were doing. It is now a normal Herdr chat, seated as a tab in a workspace of its own.

- `herdr-plugin.toml`: pane `placement = "tab"`. The 90% `width` and `height` are gone.
- `open.sh` seats the chat:
  - First open: create a workspace labelled `🪔 lantern` with `--cwd $HOME`, open the chat there as a tab named `field`, then close the empty shell tab the new workspace comes with, so the workspace holds the chat alone.
  - Later opens: focus a chat that is still running, wherever its tab was moved, or seat a new one in the same workspace.
  - Lookup order: a remembered pane that is still a live `Lantern` pane (it names its own workspace), then a remembered workspace id that still carries the `🪔 lantern` label, then the label, then create. Ids are re-checked every time, because Herdr reuses them after a restart.
  - A lock in the state directory stops two fast opens racing into two workspaces. A failed open closes the workspace that run created instead of leaving an empty shell behind.
- `lib.sh`: `helper_json_value`, `helper_workspace_id_by_label`, `helper_workspace_label`, `helper_lantern_pane_workspace`. POSIX `tr` / `sed` / `grep` only, no new dependency.
- Docs sweep: README, `howto.html`, `docs/index.html`, `prompt.md`, and the launch appendix.

## What did not change

- The open path: `hsh`, `prefix+H`, or `herdr plugin action invoke aigora.lantern.open`.
- The chat process cwd is still the plugin state workdir. Home is only where the workspace sits and the `HELPER_CWD` search root. The plugin repo is never the workspace cwd.
- Closing is still quitting the helper CLI. Escape stays inside the CLI. The tab closes with the CLI, and the lantern workspace closes with it when that chat was the only tab.

## No pin-to-top

A new workspace lands last in the sidebar. Lantern does not reorder the sidebar; drag it where you want it. That is documented in the README, the guide, and the how-to.

## Verification

- `sh tests/smoke.sh` passes. It drives `open.sh` against a stub `herdr` for six cases: first open, reuse of a live chat, a relabelled stale id (must not seat the chat there), reuse by label, a failed open (closes the new workspace, forgets it), and the lock. Fixtures are real herdr 0.7.5 JSON shapes. Two mutations of `open.sh` were checked to make the new assertions fail.
- Live on herdr 0.7.5 with a throwaway probe plugin: manifest `placement = "tab"` is accepted, `plugin pane open --placement tab --workspace <id>` seats the tab and does not dedupe across workspaces, closing the empty root pane keeps the workspace, and closing the last pane drops the workspace.
- Live end to end through `herdr plugin action invoke aigora.lantern.open`: a fresh run created a workspace labelled `🪔 lantern` holding exactly one tab named `field`, the helper CLI started with cwd `~/.local/state/herdr/plugins/aigora.lantern/workdir`, and a second invoke focused that same pane with no second workspace or tab.

Version bump lands after merge.