### PR TITLE
Document upgrading while the chat is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to Lantern, by Elves are documented here.
   The tab closes with it, and the lantern workspace closes when that chat
   was the only tab. Escape still stays inside the CLI. The helper is told
   not to close its own workspace or seat other agents in it.
+- Docs: quit the chat before upgrading, relinking, or reinstalling the
+  plugin. Herdr drops its record of a running lantern pane on install and
+  link, so that tab stops answering to `herdr plugin pane focus` and the
+  next open seats a fresh chat beside it.
 
 ## [0.2.1] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ description = "Open lantern"
 Then `herdr server reload-config`. No Herdr restart is needed for plugin
 script or config edits; reopen the lantern.
 
+Quit the chat before you upgrade, relink, or reinstall the plugin.
+`herdr plugin install` and `herdr plugin link` drop Herdr's record of a
+running lantern pane, so that tab stops answering to
+`herdr plugin pane focus` and the next open seats a fresh chat beside it.
+Close the leftover tab with `herdr pane close <pane_id>` if that happens.
+
 ## Where it sits
 
 The first open creates a workspace labelled **🔥 lantern** at your home

--- a/docs/index.html
+++ b/docs/index.html
@@ -290,6 +290,7 @@
         </li>
       </ol>
       <p class="note">Close by quitting the helper CLI. Escape stays inside the CLI. Cursor <code>agent</code>: <kbd>ctrl+c</kbd> (twice if a turn is running), or <kbd>ctrl+d</kbd> on an empty prompt.</p>
+      <p class="note">Quit the chat before you upgrade or reinstall the plugin. <code>herdr plugin install</code> drops Herdr’s record of a running lantern pane, so the next open seats a fresh chat beside the old tab. Close that one with <code>herdr pane close &lt;pane_id&gt;</code>.</p>
 
       <h2>Where it sits</h2>
       <ol class="steps">

--- a/howto.html
+++ b/howto.html
@@ -274,6 +274,7 @@ HELPER_EXTRA_ARGS=""</pre>
       </li>
     </ol>
     <p class="note">Close the chat by quitting the helper CLI. Escape stays inside the CLI. For Cursor <code>agent</code>: <kbd>ctrl+c</kbd> (twice if a turn is running), or <kbd>ctrl+d</kbd> on an empty prompt. Script and config edits do not need a Herdr restart — reopen the lantern.</p>
+    <p class="note">Quit the chat before you upgrade, relink, or reinstall the plugin. <code>herdr plugin install</code> and <code>herdr plugin link</code> drop Herdr’s record of a running lantern pane, so that tab stops answering to <code>herdr plugin pane focus</code> and the next open seats a fresh chat beside it. Close the leftover tab with <code>herdr pane close &lt;pane_id&gt;</code>.</p>
 
     <h2>Where it sits</h2>
     <ol class="steps">


### PR DESCRIPTION
Follow-on to #3, docs only.

Upgrading, relinking, or reinstalling the plugin while the lantern chat runs drops Herdr's record of that pane. It then answers `plugin pane focus` with `plugin_pane_not_found`, so the next open seats a fresh chat in the same workspace, next to a tab that is still running its CLI.

Observed on herdr 0.7.5 twice during the #3 work, both times after `herdr plugin unlink` + `herdr plugin link` on a live chat.

Added to README, `howto.html`, `docs/index.html`, and the 0.3.0 changelog entry: quit the chat before upgrading, and close a leftover tab with `herdr pane close <pane_id>`.

No code change and no version bump. 0.3.0 is not tagged yet, so the entry is edited in place.