### PR TITLE
Call the lantern tab home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Lantern, by Elves are documented here.
   placement is `tab`, and the 90% width and height are gone.
 - `open.sh` seats that chat. The first open creates a workspace labelled
   `🔥 lantern` with `--cwd $HOME`, opens the chat there as a tab named
-  `field`, and closes the empty shell tab the new workspace comes with.
+  `home`, and closes the empty shell tab the new workspace comes with.
 - Later opens focus a chat that is still running, wherever the tab was
   moved, or seat a new one in the same workspace. Lantern does not open a
   second lantern workspace, and a lock stops two fast opens racing into

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Close the leftover tab with `herdr pane close <pane_id>` if that happens.
 ## Where it sits
 
 The first open creates a workspace labelled **🔥 lantern** at your home
-directory and seats the chat there as a tab named **field**. It does not
+directory and seats the chat there as a tab named **home**. It does not
 drop a tab into whatever workspace you are in, and it closes the empty
 shell tab the new workspace comes with, so the workspace holds the chat
 alone. The lantern in the sidebar is how you find it at a glance.

--- a/docs/index.html
+++ b/docs/index.html
@@ -297,7 +297,7 @@
         <li>
           <div>
             The first open creates a workspace labelled <code>🔥 lantern</code> at your home
-            directory and seats the chat there as a tab named <code>field</code>. Nothing is dropped
+            directory and seats the chat there as a tab named <code>home</code>. Nothing is dropped
             into the workspace you are working in, and the empty shell tab of the new workspace is
             closed, so the chat sits alone. The lantern in the sidebar is how you spot it.
           </div>
@@ -325,7 +325,7 @@
       <div class="shots">
         <figure class="shot">
           <div class="frame">
-            <div class="chrome"><span class="dot live"></span> 🔥 lantern · field · Cursor agent</div>
+            <div class="chrome"><span class="dot live"></span> 🔥 lantern · home · Cursor agent</div>
             <pre class="term"><span class="dim">THE HERD IN THE FIELD</span>
 
 <span class="need">NEEDS YOU</span>

--- a/howto.html
+++ b/howto.html
@@ -281,7 +281,7 @@ HELPER_EXTRA_ARGS=""</pre>
       <li>
         <div>
           The first open creates a workspace labelled <code>🔥 lantern</code> at your home directory
-          and seats the chat there as a tab named <code>field</code>. It is not dropped into the
+          and seats the chat there as a tab named <code>home</code>. It is not dropped into the
           workspace you happen to be in, and the empty shell tab of the new workspace is closed, so
           the chat sits alone. The lantern in the sidebar is how you spot it.
         </div>

--- a/launch.sh
+++ b/launch.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Pane entrypoint: build the agent command line from the user's config and
-# exec it in the lantern pane. open.sh seats that pane as the "field" tab
+# exec it in the lantern pane. open.sh seats that pane as the "home" tab
 # in the workspace labelled "🔥 lantern". Herdr injects HERDR_PLUGIN_CONFIG_DIR,
 # HERDR_PLUGIN_ROOT, HERDR_BIN_PATH, and the socket env, so the agent that
 # starts here can drive Herdr directly.
@@ -114,7 +114,7 @@ Runtime (injected by launch.sh; do not ignore):
   (the new pane may still be coming up to a shell prompt).
 - Search from $search_root plus the usual project roots. You are the lantern,
   not an elf; do not edit files in this workdir.
-- You are the "field" tab in the dedicated lantern workspace (labelled
+- You are the "home" tab in the dedicated lantern workspace (labelled
   "🔥 lantern" unless the user renamed it). Seat new agents in their own
   repository workspace, never in this one. Never close this workspace,
   this tab, or your own pane.

--- a/open.sh
+++ b/open.sh
@@ -2,7 +2,7 @@
 # Action entrypoint: light the lantern in its own workspace.
 #
 # First open: create a workspace labelled "🔥 lantern" with --cwd $HOME and
-# seat the lantern chat there as a tab named "field", then drop the empty
+# seat the lantern chat there as a tab named "home", then drop the empty
 # shell tab the new workspace came with. Later opens: focus the chat that
 # is already running, or seat a new one in that same workspace. Herdr
 # appends a new workspace at the end of the sidebar; there is no
@@ -19,7 +19,7 @@ plugin_root=${HERDR_PLUGIN_ROOT:-$(CDPATH= cd -- "$(dirname "$0")" && pwd)}
 # pane_title must match [[panes]].title in herdr-plugin.toml, because
 # open.sh uses it to recognise a live lantern chat.
 workspace_label='🔥 lantern'
-tab_label=field
+tab_label=home
 pane_title=Lantern
 
 die() {

--- a/prompt.md
+++ b/prompt.md
@@ -57,7 +57,7 @@ beyond this list.
 Ground rules:
 
 - You are the light, not an elf. Do not edit files or do the agent's work.
-- You sit in the `field` tab of the lantern's own workspace (labelled
+- You sit in the `home` tab of the lantern's own workspace (labelled
   `🔥 lantern` unless the user renamed it). Seat new agents in their own
   repository workspace, never in this one, and never close this workspace
   or tab.

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -188,7 +188,7 @@ logged 'workspace create --cwd' || fail "first open should create a workspace"
 logged '--label 🔥 lantern' || fail "first open should use the lantern label"
 logged 'plugin pane open --plugin aigora.lantern --entrypoint helper --placement tab --workspace w9' ||
     fail "first open should seat a tab in the new workspace"
-logged 'tab rename w9:t2 field' || fail "first open should name the tab"
+logged 'tab rename w9:t2 home' || fail "first open should name the tab"
 logged 'pane close w9:p1' || fail "first open should close the empty shell"
 [ "$(cat "$open_state/workspace.id")" = w9 ] || fail "first open workspace state"
 [ "$(cat "$open_state/pane.id")" = w9:p2 ] || fail "first open pane state"


### PR DESCRIPTION
Follow-on to #3 and #4. One constant plus the doc sweep.

`field` came from the product line (the herd is in the field), but it reads as jargon in the sidebar. `🔥 lantern` > `home` is plain.

Changed in `open.sh` (`tab_label`), the launch appendix, `prompt.md`, README, `howto.html`, `docs/index.html`, the 0.3.0 changelog entry, and the smoke test that asserts the rename call.

No version bump. Tab names are display only: the chat is identified by the pane title `Lantern`, so a tab already named `field` keeps working and a user rename never breaks reuse.

`sh tests/smoke.sh` passes.