### PR TITLE
Close the bridge mutate-gate PATH hole and ship 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.5.1] - 2026-08-19
+
+### Fixed
+
+- `bridge.sh` used `helper_prepend_path` for the mutate-gate wrapper after
+  `helper_extend_user_path` had already put Homebrew in front. That is the
+  same PATH hole `launch.sh` closed in 0.5.0: on a machine whose PATH already
+  carried the plugin's `bin`, a bare `herdr` from an allowlisted chat sender
+  reached the real binary and nobody was asked. The bridge now force-fronts
+  the wrapper the same way the lantern pane does.
+- The remote appendix still handed the helper a ready-to-run
+  `HERDR_HELPER_OK=1 herdr …` line. `prompt.md` had that pattern removed in
+  0.5.0 so an agent would not paste the prefix without asking; the bridge
+  reintroduced it for the chat path. It now describes the prefix the same way
+  `launch.sh` does, without a command to copy.
+- Exported channel tokens reached the headless helper. The README tells
+  people to keep secrets in the environment, `subprocess.run` inherited
+  that environment, and the helper has Bash, so a prompt-injected turn
+  could `printenv` the WhatsApp app secret that gates the public webhook.
+  The child now gets a copy of the environment with those keys removed.
+  File-sourced secrets remain readable to the same account.
+
+### Changed
+
+- The published pages (`docs/index.html`, `howto.html`) now walk through
+  opening the bridge, filling `bridge.conf`, `--check`, and the Slack-first
+  trial, instead of one paragraph that pointed at the README. Version strings
+  on those pages, the README, and the manifest are 0.5.1.
+- "What a sender gets" named Claude's `--allowed-tools` list as if Codex got
+  it too. Codex is started as `codex exec` with no extra permission flags.
+
 ## [0.5.0] - 2026-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.5.0** — a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.5.1** — a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 
@@ -275,10 +275,12 @@ limit.
 ### What a sender gets
 
 **An allowlisted sender gets a shell on this machine.** The headless helper
-runs as the user who started the bridge, with
-`--allowed-tools "Bash,Read,Glob,Grep,LS"` and no sandbox. `Bash` is an
-ordinary shell: it can read, write, and delete anything that account can, and
-reach the network. The `bin/herdr` wrapper gates mutating **`herdr`
+runs as the user who started the bridge. Claude is started with
+`--allowed-tools "Bash,Read,Glob,Grep,LS"` and no sandbox flag. Codex is
+started as `codex exec` with no extra permission flags, so it uses that
+CLI's own defaults. `Bash` (when the helper has it) is an ordinary shell:
+it can read, write, and delete anything that account can, and reach the
+network. The `bin/herdr` wrapper gates mutating **`herdr`
 subcommands** — create, start, focus, close, prompt, `send-*` — and nothing
 else. It is not a sandbox, and it does not stand between a message and the
 rest of your files.

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -467,9 +467,10 @@ Runtime (injected by the Lantern Bridge; do not ignore):
   Inspect commands (list/read/get) run as usual. Mutating commands (create,
   start, focus, close, remove, prompt, send-*) are blocked until the user
   confirms the exact path or target. Ask for that confirmation as a chat
-  message, wait for their answer, then rerun:
-    HERDR_HELPER_OK=1 herdr <same command>
-  There is no approval UI here. The chat is the only place to ask.
+  message, wait for their answer, then rerun that same command with
+  HERDR_HELPER_OK=1 in front of it. Never write that prefix into a command
+  they have not confirmed. There is no approval UI here. The chat is the
+  only place to ask.
 - Never call /opt/homebrew/bin/herdr or another absolute herdr path.
 - Default --kind for agent start is %s unless the user names one.
 - Search from %s plus the usual project roots. You are the lantern, not an
@@ -521,6 +522,21 @@ def mark_session(workdir: Path) -> None:
     marker.write_text("", encoding="utf-8")
 
 
+def helper_env(source=None) -> dict:
+    """Environment the headless helper is allowed to see.
+
+    The README tells people to export tokens instead of writing them into
+    bridge.conf. Those names then sit in the daemon's environment, and a
+    subprocess.run with no env= hands them to a helper that has Bash. The
+    daemon still needs the tokens to talk to the APIs; the child does not.
+    File-sourced secrets remain readable to the same account.
+    """
+    env = dict(os.environ if source is None else source)
+    for key in SECRET_KEYS:
+        env.pop(key, None)
+    return env
+
+
 def run_helper(cfg: dict, helper: str, workdir: Path, text: str, timeout=HELPER_TIMEOUT):
     """Run one headless turn. Returns the reply text for the channel.
 
@@ -537,6 +553,7 @@ def run_helper(cfg: dict, helper: str, workdir: Path, text: str, timeout=HELPER_
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=timeout,
+            env=helper_env(),
         )
     except subprocess.TimeoutExpired:
         log("helper timed out after %ds" % timeout)

--- a/bridge.sh
+++ b/bridge.sh
@@ -94,7 +94,12 @@ fi
     die "could not find the plugin config dir; run this through Herdr, or install the plugin"
 mkdir -p "$config_dir" || die "could not create $config_dir"
 
-helper_prepend_path "$plugin_root/bin"
+# Same control launch.sh uses, and for the same reason: prepend leaves a
+# directory that is already on PATH in its inherited position, and
+# helper_extend_user_path has already put Homebrew in front of that. The
+# headless helper the daemon starts inherits this PATH, so a bare `herdr`
+# from an allowlisted sender would skip the mutate gate.
+helper_force_front_path "$plugin_root/bin"
 
 if [ -n "${HERDR_BIN_PATH:-}" ] && [ -x "$HERDR_BIN_PATH" ]; then
     case $HERDR_BIN_PATH in

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.5.0 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.5.1 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>
@@ -389,7 +389,32 @@ No Elves install required. If there are no
       </ul>
 
       <h2>Use it from your phone</h2>
-      <p>The Lantern Bridge is a second pane that answers Telegram, WhatsApp, and Slack messages with the same lantern. Open it with <code>herdr plugin action invoke aigora.lantern.bridge</code> and leave it running. It does not read the lantern chat: every conversation gets its own workdir seeded with the same prompt, and a headless <code>claude</code> or <code>codex</code> answers there. A channel turns on when its credential is set and refuses to start until its allowlist names who may talk to it, mutating <code>herdr</code> still waits for your confirmation as a chat message, and the WhatsApp webhook verifies every request signature before it parses anything. Setup per channel is in the <a href="https://github.com/aigorahub/herdr-lantern#use-the-lantern-from-telegram-whatsapp-or-slack">README</a>.</p>
+      <p>The Lantern Bridge is a second pane that answers Telegram, WhatsApp, and Slack with the same lantern. It does not read the lantern chat: every conversation gets its own workdir, and a headless <code>claude</code> or <code>codex</code> answers there.</p>
+      <ol class="steps">
+        <li>
+          <div>
+            Open it and leave it running:
+            <pre>herdr plugin action invoke aigora.lantern.bridge</pre>
+            Or from a checkout: <code>sh bridge.sh</code>. Invoking the action again focuses the pane that is already open. A second daemon on the same state directory is refused by name.
+          </div>
+        </li>
+        <li>
+          <div>
+            Fill in <code>bridge.conf</code> in the plugin config directory. A channel turns on when its credential is set, and refuses to start until its allowlist names who may talk to it.
+            <pre>$EDITOR "$(herdr plugin config-dir aigora.lantern)/bridge.conf"</pre>
+            Every key falls back to an environment variable of the same name, so tokens can stay out of the file.
+          </div>
+        </li>
+        <li>
+          <div>
+            Check the config without touching the network:
+            <pre>sh bridge.sh --check</pre>
+          </div>
+        </li>
+      </ol>
+      <p>Slack is the easiest trial: it polls, so nothing on your machine has to be reachable from outside. Create an app with the bot scopes <code>channels:history</code> and <code>chat:write</code>, invite it, put the channel id (<code>C…</code>) and your member id (<code>U…</code>) in the file, and export the <code>xoxb-</code> token in the same shell that runs the daemon. Step by step: <a href="https://github.com/aigorahub/herdr-lantern/blob/main/docs/slack-trial.md">docs/slack-trial.md</a>.</p>
+      <p>Telegram long-polls the same way: a chat id on the allowlist is a person, not a room. WhatsApp is a localhost webhook behind a tunnel; every POST is checked against <code>X-Hub-Signature-256</code> before it is parsed, which is why the app secret is required. Setup per channel is in the <a href="https://github.com/aigorahub/herdr-lantern#use-the-lantern-from-telegram-whatsapp-or-slack">README</a>.</p>
+      <p class="note"><strong>An allowlisted sender gets a shell on this machine.</strong> Put only your own ids on the lists. Mutating <code>herdr</code> still waits for your confirmation, as a chat message.</p>
 
       <h2>Pick your helper CLI</h2>
       <p>The lantern chat is one CLI. That is yours. It is not a shared team model. <code>HELPER_SPAWN_KIND</code> is separate: the default <code>--kind</code> when Lantern starts an agent for your work (usually <code>claude</code>).</p>

--- a/docs/slack-trial.md
+++ b/docs/slack-trial.md
@@ -85,10 +85,12 @@ answers anyone who finds the bot is a bridge that runs commands for anyone who
 finds the bot.
 
 **What an allowlisted member gets is a shell on this machine.** The headless
-helper runs as the account that started the bridge, with
-`--allowed-tools "Bash,Read,Glob,Grep,LS"` and no sandbox. `Bash` is an
-ordinary shell: it can read, write, and delete whatever that account can, and
-reach the network. The `bin/herdr` wrapper described further down gates
+helper runs as the account that started the bridge. Claude is started with
+`--allowed-tools "Bash,Read,Glob,Grep,LS"` and no sandbox flag. Codex is
+started as `codex exec` with no extra permission flags, so it uses that
+CLI's own defaults. `Bash` (when the helper has it) is an ordinary shell:
+it can read, write, and delete whatever that account can, and reach the
+network. The `bin/herdr` wrapper described further down gates
 mutating **`herdr` subcommands** and nothing else — it is not a sandbox, and it
 does not stand between a message and the rest of your files.
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.5.0"
+version = "0.5.1"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.5.0</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.5.1</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>
@@ -304,7 +304,10 @@ HELPER_EXTRA_ARGS=""</pre>
     <p class="note">The chat runs in the plugin state workdir. Home is only where the workspace sits and the search root the helper is told about (<code>HELPER_CWD</code>). Your repositories keep their own workspaces. When the helper CLI exits, the tab closes, and the lantern workspace closes with it if that chat was the only tab. Herdr reuses workspace and pane ids after a restart, so Lantern checks the remembered ids before it trusts them: keep the <code>🔥 lantern</code> label if you want that workspace reused after the chat closes.</p>
 
     <h2>Use it from your phone</h2>
-    <p>The Lantern Bridge is a second pane that answers Telegram, WhatsApp, and Slack messages with the same lantern. Open it with <code>herdr plugin action invoke aigora.lantern.bridge</code> and leave it running. Fill in <code>bridge.conf</code> in the same config directory: a channel turns on when its credential is set, and refuses to start until its allowlist names who may talk to it. Mutating <code>herdr</code> is still blocked until you confirm, and the confirmation is a chat message. <code>sh bridge.sh --check</code> validates a config without touching the network. Setup per channel is in the <a href="https://github.com/aigorahub/herdr-lantern#use-the-lantern-from-telegram-whatsapp-or-slack">README</a>.</p>
+    <p>The Lantern Bridge is a second pane that answers Telegram, WhatsApp, and Slack with the same lantern. Open it with <code>herdr plugin action invoke aigora.lantern.bridge</code> and leave it running, or <code>sh bridge.sh</code> from a checkout.</p>
+    <p>Fill in <code>bridge.conf</code> in the same config directory as <code>helper.conf</code>. A channel turns on when its credential is set, and refuses to start until its allowlist names who may talk to it. Tokens can stay in the environment: every key falls back to a variable of the same name. <code>sh bridge.sh --check</code> validates a config without touching the network.</p>
+    <p>Slack is the easiest trial (it polls; nothing has to be reachable). Telegram long-polls. WhatsApp is a localhost webhook behind a tunnel, and every POST is checked against <code>X-Hub-Signature-256</code> before it is parsed. Setup per channel, including what an allowlisted sender actually gets, is in the <a href="https://github.com/aigorahub/herdr-lantern#use-the-lantern-from-telegram-whatsapp-or-slack">README</a>. Slack walkthrough: <a href="https://github.com/aigorahub/herdr-lantern/blob/main/docs/slack-trial.md">docs/slack-trial.md</a>.</p>
+    <p class="note">Mutating <code>herdr</code> is still blocked until you confirm, and the confirmation is a chat message. Put only your own ids on the allowlists.</p>
 
     <h2>What to say</h2>
     <ul class="says">

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -501,6 +501,46 @@ class RunHelperTest(unittest.TestCase):
         self.assertEqual(reply, "the answer")
         self.assertTrue(lb.has_session(self.workdir))
 
+    def test_helper_env_drops_channel_secrets(self):
+        source = {
+            "PATH": "/bin",
+            "HOME": "/home/j",
+            "KEEP": "1",
+            "WHATSAPP_APP_SECRET": "x",
+            "SLACK_BOT_TOKEN": "y",
+            "TELEGRAM_BOT_TOKEN": "z",
+            "WHATSAPP_ACCESS_TOKEN": "a",
+            "WHATSAPP_VERIFY_TOKEN": "b",
+        }
+        env = lb.helper_env(source)
+        self.assertEqual(env["PATH"], "/bin")
+        self.assertEqual(env["KEEP"], "1")
+        for key in lb.SECRET_KEYS:
+            self.assertNotIn(key, env)
+        # The daemon still has the tokens; only the child copy is scrubbed.
+        self.assertEqual(source["WHATSAPP_APP_SECRET"], "x")
+
+    def test_run_helper_passes_the_scrubbed_env(self):
+        captured = {}
+        original = lb.subprocess.run
+        self.addCleanup(setattr, lb.subprocess, "run", original)
+
+        def fake_run(*args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            done = type("Completed", (), {})()
+            done.returncode = 0
+            done.stdout = b"ok\n"
+            done.stderr = b""
+            return done
+
+        lb.subprocess.run = fake_run
+        lb.run_helper(base_config(BRIDGE_HELPER="claude"), "claude", self.workdir, "hi")
+        child = captured.get("env")
+        self.assertIsNotNone(child)
+        for key in lb.SECRET_KEYS:
+            self.assertNotIn(key, child)
+        self.assertIn("PATH", child)
+
 
 def telegram_update(
     update_id,

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -142,6 +142,8 @@ case $front_real in
 esac
 grep -q 'helper_force_front_path "$plugin_root/bin"' "$root/launch.sh" ||
     fail "launch.sh should force the wrapper to the front of PATH"
+grep -q 'helper_force_front_path "$plugin_root/bin"' "$root/bridge.sh" ||
+    fail "bridge.sh should force the wrapper to the front of PATH"
 rm -rf "$resolve_dir"
 
 # The plugin must never invoke bare `bash`. On Windows the bash on PATH is the
@@ -163,6 +165,9 @@ grep -q 'CLAUDE.md' "$root/launch.sh" || fail "launch writes CLAUDE.md"
 # up typing into other people's panes with nobody's permission.
 if grep -q 'HERDR_HELPER_OK=1 herdr' "$root/prompt.md"; then
     fail "prompt.md should not hand out a prefixed herdr command to paste"
+fi
+if grep -q 'HERDR_HELPER_OK=1 herdr' "$root/bin/lantern-bridge"; then
+    fail "lantern-bridge should not hand out a prefixed herdr command to paste"
 fi
 for gated_verb in prompt send-keys start focus close remove; do
     grep -qF "$gated_verb" "$root/prompt.md" ||
@@ -211,6 +216,10 @@ for version_page in howto.html docs/index.html; do
         grep -qvF "v$version"; then
         fail "$version_page still carries a version that is not v$version"
     fi
+    grep -qF "Lantern Bridge" "$root/$version_page" ||
+        fail "$version_page does not name the Lantern Bridge"
+    grep -qF "bridge.conf" "$root/$version_page" ||
+        fail "$version_page does not name bridge.conf"
 done
 
 # Every key the example file offers has to be documented, or people fill in a


### PR DESCRIPTION
## Summary
- PR #7 (Lantern Bridge) merged without review. A plain Fugu review plus a host pass found the mutate-gate PATH hole on `bridge.sh` (the lantern pane was fixed in 0.5.0; the chat daemon was not), a paste-ready `HERDR_HELPER_OK=1 herdr` line in the remote appendix, and exported channel tokens inherited by the headless helper.
- The published pages now walk through opening the bridge, `bridge.conf`, `--check`, and the Slack-first trial instead of one paragraph pointing at the README. Manifest / README / changelog / HTML all read 0.5.1.
- Codex is no longer described as if it received Claude's `--allowed-tools` list.

## Test plan
- [x] `sh tests/smoke.sh` green locally
- [ ] CI green on Linux, macOS, and Windows
- [ ] After merge, GitHub Pages deploys `docs/` and a `v0.5.1` GitHub release is published (0.4.0 and 0.5.0 never got releases; GitHub is still on v0.3.0)


Made with [Cursor](https://cursor.com)