### PR TITLE
Slack: thread replies, DM conversations, and autostart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ All notable changes to Lantern, by Elves are documented here.
 - Slack DMs. The bridge now opens and polls each allowlisted member's DM with
   the bot, besides the one watched channel. Needs the `im:history` and
   `im:write` scopes and an app reinstall; without them the bridge logs which
-  scope is missing and runs channel-only, as before.
+  scope is missing and runs channel-only, as before. It also needs the app's
+  Messages tab switched on under App Home, which is a setting rather than a
+  scope: until it is, Slack refuses to let anyone send the app a DM at all.
+  Both the README and the Slack trial guide say so, and the trial guide's
+  troubleshooting table names the symptom.
 - `BRIDGE_AUTOSTART`. Set it to `1` in `bridge.conf` and a `[[startup]]` hook
   has the Herdr server seat the bridge pane itself, so no terminal stays open
   for the bridge. The hook reads the config file only, exits quietly when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Lantern, by Elves are documented here.
 
 ## [0.6.0] - 2026-08-20
 
+### Fixed
+
+These came out of a pre-merge review of the Slack work below, and every one of
+them was introduced by it.
+
+- The dedupe set lost a whole conversation at a time. It changed from holding
+  timestamps to holding `(conversation, timestamp)` pairs, but the eviction
+  still sorted the pairs, which sorts by conversation id first. Channel ids
+  start with `C` and DM ids with `D`, so a busy DM evicted every channel entry
+  before touching any DM entry, newest included. That newest entry is the
+  cursor boundary the set exists to protect, so the next poll could answer the
+  same channel message twice. Eviction now sorts on the timestamp.
+- Splitting a long reply ate the shape it was sent with. The chunk boundary
+  did `rstrip()` and `lstrip("\n ")`, so a blank line between steps vanished
+  and an indented continuation line arrived flush left. Exactly one separator
+  character is now removed, which is what the new formatting instruction
+  promises the helper.
+- A DM that opened but could not be read took the channel down with it, once
+  per poll, forever. That is the shape of `im:write` granted without
+  `im:history`. The failure raised out of the poll, and the retry loop logged
+  only the exception class, discarding the error slug that names the cause.
+  Such a DM is now dropped with the slug and the missing scope named, and the
+  channel keeps working.
+- A network blip while the daemon started turned DMs off for the life of the
+  process and reported it as a missing scope. Opening is now retried on a slow
+  timer until at least one DM opens.
+- The threaded footer told people to DM the bot based on whether anyone had a
+  DM open, not whether they did. Someone whose own DM failed to open was sent
+  somewhere nothing is read. The footer now follows the person it is answering.
+- The autostart hook read `BRIDGE_AUTOSTART` anchored at column 0 and matched
+  only lowercase, while the daemon's parser strips the line first. An indented
+  key was therefore valid config that the hook could not see, and the symptom
+  was a key that looks set, no bridge, and nothing logged. The hook now matches
+  the daemon, accepts any case, and says so when the value is set to something
+  it does not understand.
+
 ### Added
 
 - Slack DMs. The bridge now opens and polls each allowlisted member's DM with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,14 @@ All notable changes to Lantern, by Elves are documented here.
   the thread reaches nobody; the line says where to continue instead.
 - Slack polling is round-robin, one conversation per pass, so watching the
   DMs costs the same request rate as watching the channel alone.
-- The remote appendix pushes harder on brevity: two or three short sentences
-  is the normal reply, detail only on request, no restating the question.
+- The remote appendix separates brevity from formatting. A conversational
+  answer is two or three short sentences, but anything with a shape, a list,
+  steps, a recipe, or output relayed from another agent, is passed through
+  with its own line breaks and numbering. The first version of this said only
+  "keep replies short" with "no headings, no tables", and a relayed recipe
+  came back as paragraphs with the numbering run inline, losing the shape the
+  user had asked to see. Length is explicitly not a reason to condense: line
+  breaks reach the chat app unchanged and long replies are split at one.
 
 ## [0.5.1] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.6.0] - 2026-08-20
+
+### Added
+
+- Slack DMs. The bridge now opens and polls each allowlisted member's DM with
+  the bot, besides the one watched channel. Needs the `im:history` and
+  `im:write` scopes and an app reinstall; without them the bridge logs which
+  scope is missing and runs channel-only, as before.
+- `BRIDGE_AUTOSTART`. Set it to `1` in `bridge.conf` and a `[[startup]]` hook
+  has the Herdr server seat the bridge pane itself, so no terminal stays open
+  for the bridge. The hook reads the config file only, exits quietly when the
+  key is off or the file does not exist, and never seeds anything.
+
+### Changed
+
+- Slack replies follow the message and the session follows the person. A
+  channel message is answered in its own thread, so the channel stays
+  readable; a DM is answered in the DM; and both share one conversation per
+  allowlisted member, so a question asked in the channel continues in the DM
+  without starting over. Sessions used to be keyed by the channel, so an
+  existing conversation starts fresh once on upgrade.
+- Threaded answers carry one line saying the bridge cannot read the thread.
+  Slack's history API does not return thread replies, so a reply typed into
+  the thread reaches nobody; the line says where to continue instead.
+- Slack polling is round-robin, one conversation per pass, so watching the
+  DMs costs the same request rate as watching the channel alone.
+- The remote appendix pushes harder on brevity: two or three short sentences
+  is the normal reply, detail only on request, no restating the question.
+
 ## [0.5.1] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -256,7 +256,11 @@ their messages are answered there and everyone else's are dropped.
 
 **Slack.** Create an app at api.slack.com, add the bot scopes
 `channels:history`, `chat:write`, `im:history`, and `im:write`, install it to
-the workspace, and invite the bot to the channel (`/invite @yourbot`).
+the workspace, and invite the bot to the channel (`/invite @yourbot`). For the
+DM half, also switch on **App Home** → **Show Tabs** → **Messages Tab** and its
+checkbox: without it Slack will not let anyone send the app a direct message,
+whatever the scopes say. That is a setting, not a scope, so it needs no
+reinstall; the scopes do.
 `SLACK_CHANNEL` is that channel's id (`C…`), and `SLACK_ALLOWED_USERS` holds
 your member id (`U…`). The bridge polls that one channel and each allowlisted
 member's DM with the bot, and ignores everything it did not hear from an

--- a/README.md
+++ b/README.md
@@ -294,7 +294,11 @@ token, and subscribe to `messages`. Every POST is checked against
 required rather than optional: without it the tunnel is an open door.
 
 Text messages only, both directions. Replies are split at each provider's
-limit.
+limit, at a line break where there is one nearby, so a list stays a list.
+
+Conversational answers are short by instruction. Content is not: a list, a
+set of steps, or output relayed from another agent is passed through with its
+own line breaks and numbering rather than condensed into a paragraph.
 
 ### What a sender gets
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.5.1** — a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.6.0** — a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 
@@ -182,6 +182,13 @@ The **Lantern Bridge** is a second pane that answers chat messages with the
 same lantern. Open it with `herdr plugin action invoke aigora.lantern.bridge`,
 or run `sh bridge.sh` from a checkout. Leave it running; it is a daemon.
 
+No terminal has to stay open for it. The pane lives inside the Herdr server,
+and `BRIDGE_AUTOSTART="1"` in `bridge.conf` makes the server seat that pane
+itself on startup, so the bridge is simply up whenever Herdr is. Autostart
+reads the config file only, so the tokens must live in `bridge.conf` (it is
+created `0600`) rather than in an exported variable, which no longer exists
+by the time the server boots.
+
 One bridge runs at a time. Invoking the action again focuses the pane that is
 already open, and a second daemon on the same state directory refuses to start
 and names the lock file — two pollers on one token would answer every message
@@ -204,6 +211,7 @@ is empty, so tokens can stay out of the file.
 
 | Key | What it is |
 | --- | --- |
+| `BRIDGE_AUTOSTART` | `1`, `yes`, or `true`: the Herdr server opens the bridge pane on startup |
 | `BRIDGE_HELPER` | `claude` or `codex`; empty = first of those on `PATH` |
 | `BRIDGE_MODEL` | optional `--model` |
 | `BRIDGE_EFFORT` | `claude --effort`, `codex model_reasoning_effort` |
@@ -247,12 +255,24 @@ the bridge in a group, allowlist the user ids of the people who may drive it;
 their messages are answered there and everyone else's are dropped.
 
 **Slack.** Create an app at api.slack.com, add the bot scopes
-`channels:history` and `chat:write`, install it to the workspace, and invite
-the bot to the channel (`/invite @yourbot`). `SLACK_CHANNEL` is that channel's
-id (`C…`), and `SLACK_ALLOWED_USERS` holds your member id (`U…`). The bridge
-polls that one channel and ignores everything it did not hear from an
-allowlisted human. Step by step, including where to find both ids and what to
-do when it does not answer: [docs/slack-trial.md](docs/slack-trial.md).
+`channels:history`, `chat:write`, `im:history`, and `im:write`, install it to
+the workspace, and invite the bot to the channel (`/invite @yourbot`).
+`SLACK_CHANNEL` is that channel's id (`C…`), and `SLACK_ALLOWED_USERS` holds
+your member id (`U…`). The bridge polls that one channel and each allowlisted
+member's DM with the bot, and ignores everything it did not hear from an
+allowlisted human.
+
+Replies follow the message and the session follows the person. A message in
+the channel is answered in its own thread, so the channel stays readable; a
+DM is answered in the DM. Both places share one conversation per person, so a
+question asked in the channel can be continued in the DM without starting
+over. Threads are reply-only: Slack's history API does not return thread
+replies, so the bridge cannot see anything typed inside one, and the threaded
+answer says so. Without the two `im:` scopes the bridge logs which scope is
+missing and runs channel-only.
+
+Step by step, including where to find both ids and what to do when it does
+not answer: [docs/slack-trial.md](docs/slack-trial.md).
 
 **WhatsApp.** Meta Cloud API only. Create a Meta app with the WhatsApp
 product, note the phone number id, the access token, and the app secret. The

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -93,6 +93,9 @@ HELPER_TIMEOUT = 900
 TELEGRAM_POLL = 50
 # Slack has no long poll on this endpoint, so it is a plain interval.
 SLACK_POLL = 3.0
+# How long to wait before asking Slack to open the DMs again, when the last
+# attempt opened none.
+DM_OPEN_RETRY = 60.0
 HTTP_TIMEOUT = 30
 LONG_POLL_TIMEOUT = TELEGRAM_POLL + 15
 
@@ -427,13 +430,18 @@ def split_message(text: str, limit: int) -> list:
             chunks.append(rest[:cut])
             rest = rest[cut:]
             continue
-        chunk = rest[:cut].rstrip()
-        rest = rest[cut:].lstrip("\n ")
-        # A window that held nothing but whitespace up to the break leaves an
-        # empty chunk, and every provider rejects an empty message -- so the
-        # send raises, the dispatch loop logs one "send failed" line, and the
-        # whole reply is lost rather than one blank line of it.
-        if chunk:
+        # Take everything up to the break and drop exactly the one character
+        # that was the break. Stripping more ate the shape the message was
+        # sent for: a blank line between steps disappeared, and an indented
+        # continuation line arrived flush left. The appendix now promises the
+        # helper that line breaks survive, so this has to keep that promise.
+        chunk = rest[:cut]
+        rest = rest[cut + 1:]
+        # A window holding nothing but whitespace up to the break leaves a
+        # blank chunk, and every provider rejects an empty message -- the send
+        # raises, the dispatch loop logs one "send failed" line, and the whole
+        # reply is lost rather than one blank line of it.
+        if chunk.strip():
             chunks.append(chunk)
     if rest:
         chunks.append(rest)
@@ -793,7 +801,10 @@ class SlackAdapter(Adapter):
         self.seen = set()
         # DM conversation id -> allowlisted user id. Filled by open_dms.
         self.dms = {}
-        self._dms_tried = False
+        # Not a boolean: a network blip at daemon start (a laptop resuming, or
+        # Herdr autostarting before DHCP) would otherwise turn DMs off for the
+        # life of the process and report it as a missing scope.
+        self._dms_next_try = 0.0
         self._poll_order = []
 
     def headers(self) -> dict:
@@ -814,14 +825,20 @@ class SlackAdapter(Adapter):
     def dm_open_payload(self, user: str):
         return ("https://slack.com/api/conversations.open", {"users": user})
 
-    def open_dms(self) -> None:
-        """One conversations.open per allowlisted user, once.
+    def open_dms(self, now=None) -> None:
+        """One conversations.open per allowlisted user.
 
         A failure is a log line, not a stop: a token installed before the
         im:history/im:write scopes were added still runs the channel, and the
         line says what to add and that the app needs a reinstall.
+
+        Retried on a slow timer until at least one DM opens, so a blip at
+        startup costs a minute rather than the whole run.
         """
-        self._dms_tried = True
+        now = time.time() if now is None else now
+        if self.dms or now < self._dms_next_try:
+            return
+        self._dms_next_try = now + DM_OPEN_RETRY
         for user in sorted(self.allowed):
             url, payload = self.dm_open_payload(user)
             try:
@@ -844,6 +861,8 @@ class SlackAdapter(Adapter):
                 self.dms[dm] = user
                 self.cursors.setdefault(dm, self.started)
         if self.dms:
+            # Opened at least one, so stop asking.
+            self._dms_next_try = float("inf")
             log("slack: watching %d DM(s) besides the channel" % len(self.dms))
 
     def remember(self, conversation: str, ts: str) -> None:
@@ -851,7 +870,15 @@ class SlackAdapter(Adapter):
         if len(self.seen) > 512:
             # Bounded on purpose: this runs for weeks. Anything this old is
             # far behind its cursor and can never come back.
-            for old in sorted(self.seen)[:256]:
+            #
+            # Prune by timestamp, never by tuple order. Sorting the tuples
+            # themselves sorts by conversation id first, so it would evict one
+            # whole conversation before touching any other: channel ids start
+            # with C and DM ids with D, so busy DMs would wipe the channel's
+            # memory entirely, newest entry included. That newest entry is the
+            # cursor boundary this set exists to protect, and losing it means
+            # answering the same message twice.
+            for old in sorted(self.seen, key=lambda item: item[1])[:256]:
                 self.seen.discard(old)
 
     def parse_history(self, payload: dict, conversation=None):
@@ -892,9 +919,9 @@ class SlackAdapter(Adapter):
             if not isinstance(text, str) or not text.strip():
                 continue
             if conversation == self.channel:
-                reply_to = (conversation, ts)
+                reply_to = (conversation, ts, user)
             else:
-                reply_to = (conversation, None)
+                reply_to = (conversation, None, user)
             accepted.append((user, reply_to, text.strip()))
         return accepted, oldest
 
@@ -910,44 +937,68 @@ class SlackAdapter(Adapter):
             self._poll_order = [self.channel] + sorted(self.dms)
         return [self._poll_order.pop(0)]
 
+    def drop_conversation(self, conversation: str) -> None:
+        self.dms.pop(conversation, None)
+        self.cursors.pop(conversation, None)
+        self._poll_order = [c for c in self._poll_order if c != conversation]
+
     def poll_once(self) -> None:
-        if not self._dms_tried:
-            self.open_dms()
+        self.open_dms()
         for conversation in self.poll_conversations():
             payload = http_json(self.history_url(conversation), headers=self.headers())
             if not payload.get("ok", False):
                 # Slack reports failure in the body with HTTP 200. The error
-                # slug is a fixed vocabulary, never a token.
-                raise RuntimeError(
-                    "slack api error: %s" % payload.get("error", "unknown")
-                )
+                # slug is a fixed vocabulary, never a token, so it is safe to
+                # log and it is the only thing that names the cause.
+                slug = payload.get("error", "unknown")
+                if conversation in self.dms:
+                    # A DM that opens but cannot be read is the shape of
+                    # im:write granted without im:history. Raising here would
+                    # retry it every cycle forever with the slug discarded, and
+                    # take the channel's poll down with it each time. Drop the
+                    # DM, name the reason, keep the channel.
+                    log(
+                        "slack: no longer reading the DM for %s (%s); "
+                        "reading a DM needs the im:history scope and an app "
+                        "reinstall" % (self.dms[conversation], slug)
+                    )
+                    self.drop_conversation(conversation)
+                    continue
+                raise RuntimeError("slack api error: %s" % slug)
             accepted, oldest = self.parse_history(payload, conversation)
             self.cursors[conversation] = oldest
             for user, reply_to, text in accepted:
                 self.offer(user, text, reply_to=reply_to)
         time.sleep(SLACK_POLL)
 
-    def thread_footer(self) -> str:
+    def thread_footer(self, user=None) -> str:
         # The one thing a threaded answer must say: the bridge cannot read
         # this thread, so a reply typed here goes nowhere.
-        if self.dms:
+        #
+        # Whether to point at the DM depends on this person's DM, not on
+        # anyone's. open_dms carries on past a user whose DM will not open, so
+        # telling them to DM would send them somewhere nothing is read.
+        if user is not None and user in self.dms.values():
             return "(I cannot see replies in this thread. DM me to continue.)"
         return "(I cannot see replies in this thread. Post in the channel to continue.)"
 
     def split_reply_to(self, reply_to):
-        """(conversation, thread_ts) whatever shape the queue handed over.
+        """(conversation, thread_ts, user) whatever shape the queue handed over.
 
         A plain string arrives from the failure path in serve(), which sends
         to whatever it was given; treat it as a conversation with no thread.
         """
-        if isinstance(reply_to, tuple) and len(reply_to) == 2:
-            return reply_to
-        return (str(reply_to), None)
+        if isinstance(reply_to, tuple):
+            if len(reply_to) == 3:
+                return reply_to
+            if len(reply_to) == 2:
+                return (reply_to[0], reply_to[1], None)
+        return (str(reply_to), None, None)
 
     def send_payloads(self, reply_to, text: str):
-        conversation, thread_ts = self.split_reply_to(reply_to)
+        conversation, thread_ts, user = self.split_reply_to(reply_to)
         if thread_ts:
-            text = text.rstrip() + "\n\n" + self.thread_footer()
+            text = text.rstrip() + "\n\n" + self.thread_footer(user)
         payloads = []
         for chunk in split_message(text, self.limit):
             body = {"channel": conversation, "text": chunk}

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -462,9 +462,22 @@ def remote_appendix(cfg: dict, channel: str, search_root: str) -> str:
 Runtime (injected by the Lantern Bridge; do not ignore):
 
 - You are answering over a chat app (%s), not in a terminal pane. The person
-  is probably on a phone. Two or three short sentences is a normal reply;
-  give detail only when they ask for it. Plain text: no tables, no headings,
-  no code fences unless a command is the answer, no restating their question.
+  is probably on a phone, so a conversational answer is two or three short
+  sentences, and detail comes when they ask for it. Do not restate their
+  question back to them.
+- Content is not conversation. When they ask for something that has a shape,
+  a list, steps, a recipe, a plan, a file, send it with that shape intact:
+  one item per line, its own numbering, its own line breaks. Do not compress
+  it into a paragraph, and do not summarise it unless a summary is what they
+  asked for. Line breaks reach the chat app unchanged, and a reply too long
+  for one message is split for you at a line break, so length is not a reason
+  to condense.
+- Output you relayed from another agent belongs to that agent. Pass it
+  through as it came, with its own formatting, and keep your own words to a
+  line or two in front of it. Rewriting it loses the thing the user asked to
+  see.
+- No tables and no headings; both read badly on a phone. Code fences only for
+  code or a command.
 - Prefer $HERDR_BIN_PATH when calling Herdr. A wrapper is first on PATH.
   Inspect commands (list/read/get) run as usual. Mutating commands (create,
   start, focus, close, remove, prompt, send-*) are blocked until the user

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -36,6 +36,7 @@ from pathlib import Path
 SUPPORTED_HELPERS = ("claude", "codex")
 
 CONF_KEYS = (
+    "BRIDGE_AUTOSTART",
     "BRIDGE_HELPER",
     "BRIDGE_MODEL",
     "BRIDGE_EFFORT",
@@ -461,8 +462,9 @@ def remote_appendix(cfg: dict, channel: str, search_root: str) -> str:
 Runtime (injected by the Lantern Bridge; do not ignore):
 
 - You are answering over a chat app (%s), not in a terminal pane. The person
-  is probably on a phone. Keep replies short and plain: no tables, no
-  headings, no code fences unless a command is the answer.
+  is probably on a phone. Two or three short sentences is a normal reply;
+  give detail only when they ask for it. Plain text: no tables, no headings,
+  no code fences unless a command is the answer, no restating their question.
 - Prefer $HERDR_BIN_PATH when calling Herdr. A wrapper is first on PATH.
   Inspect commands (list/read/get) run as usual. Mutating commands (create,
   start, focus, close, remove, prompt, send-*) are blocked until the user
@@ -619,8 +621,13 @@ class Adapter:
     def send(self, chat_id, text: str) -> None:
         raise NotImplementedError
 
-    def offer(self, chat_id, text: str) -> None:
-        self.inbox.put((self.name, str(chat_id), text))
+    def offer(self, chat_id, text: str, reply_to=None) -> None:
+        # chat_id keys the conversation workdir; reply_to says where the
+        # answer goes. They are the same thing everywhere except Slack, where
+        # the session follows the person and the reply follows the message.
+        if reply_to is None:
+            reply_to = str(chat_id)
+        self.inbox.put((self.name, str(chat_id), reply_to, text))
 
     def run(self) -> None:
         while True:
@@ -738,7 +745,21 @@ class TelegramAdapter(Adapter):
 class SlackAdapter(Adapter):
     """Web API polling. Socket Mode needs websockets, which the stdlib lacks,
     and the Events API needs a public server; conversations.history needs
-    neither and one channel is all this watches."""
+    neither and one channel is all this watches.
+
+    Sessions follow the person, replies follow the message. A message in the
+    watched channel is answered in its own thread, so the channel stays
+    readable; the conversation itself lives in the sender's DM with the bot,
+    which the bridge also polls. One workdir per allowlisted user covers both
+    places, so a question asked in the channel can be continued in the DM
+    without starting over.
+
+    Threads are reply-only. conversations.history does not return thread
+    replies, so the bridge cannot see anything typed inside a thread; the
+    threaded answer carries one line saying so. Reading and opening DMs needs
+    the im:history and im:write scopes; without them the bridge says which
+    scope is missing and runs channel-only.
+    """
 
     name = "slack"
     limit = SLACK_LIMIT
@@ -748,40 +769,88 @@ class SlackAdapter(Adapter):
         self.token = cfg["SLACK_BOT_TOKEN"]
         self.channel = cfg["SLACK_CHANNEL"]
         self.allowed = set(split_list(cfg["SLACK_ALLOWED_USERS"]))
-        # History starts at startup. Whatever the channel said before the
+        # History starts at startup. Whatever a conversation said before the
         # bridge existed is somebody else's conversation, not a backlog.
-        self.oldest = "%.6f" % (time.time() if now is None else now)
-        # `oldest` is a boundary, not an acknowledgement: the message that sets
-        # the cursor can come back on the next poll. Remembering the ts is what
-        # stops a double answer.
+        self.started = "%.6f" % (time.time() if now is None else now)
+        # One cursor per polled conversation: the channel now, each DM once
+        # it is opened. `oldest` is a boundary, not an acknowledgement: the
+        # message that sets a cursor can come back on the next poll, so the
+        # (conversation, ts) pairs in `seen` are what stop a double answer.
+        self.cursors = {self.channel: self.started}
         self.seen = set()
+        # DM conversation id -> allowlisted user id. Filled by open_dms.
+        self.dms = {}
+        self._dms_tried = False
+        self._poll_order = []
 
     def headers(self) -> dict:
         return {"Authorization": "Bearer %s" % self.token}
 
-    def history_url(self) -> str:
+    def history_url(self, conversation=None) -> str:
+        conversation = self.channel if conversation is None else conversation
         query = urllib.parse.urlencode(
             {
-                "channel": self.channel,
-                "oldest": self.oldest,
+                "channel": conversation,
+                "oldest": self.cursors.get(conversation, self.started),
                 "limit": 100,
                 "inclusive": "false",
             }
         )
         return "https://slack.com/api/conversations.history?%s" % query
 
-    def remember(self, ts: str) -> None:
-        self.seen.add(ts)
+    def dm_open_payload(self, user: str):
+        return ("https://slack.com/api/conversations.open", {"users": user})
+
+    def open_dms(self) -> None:
+        """One conversations.open per allowlisted user, once.
+
+        A failure is a log line, not a stop: a token installed before the
+        im:history/im:write scopes were added still runs the channel, and the
+        line says what to add and that the app needs a reinstall.
+        """
+        self._dms_tried = True
+        for user in sorted(self.allowed):
+            url, payload = self.dm_open_payload(user)
+            try:
+                answer = http_json(url, payload, headers=self.headers())
+            except Exception as exc:  # noqa: BLE001 - channel-only is still a bridge
+                log(
+                    "slack: could not open the DM for %s (%s)"
+                    % (user, exc.__class__.__name__)
+                )
+                continue
+            if not answer.get("ok", False):
+                log(
+                    "slack: could not open the DM for %s (%s); "
+                    "DMs need the im:history and im:write scopes, then reinstall the app"
+                    % (user, answer.get("error", "unknown"))
+                )
+                continue
+            dm = (answer.get("channel") or {}).get("id")
+            if isinstance(dm, str) and dm:
+                self.dms[dm] = user
+                self.cursors.setdefault(dm, self.started)
+        if self.dms:
+            log("slack: watching %d DM(s) besides the channel" % len(self.dms))
+
+    def remember(self, conversation: str, ts: str) -> None:
+        self.seen.add((conversation, ts))
         if len(self.seen) > 512:
             # Bounded on purpose: this runs for weeks. Anything this old is
-            # far behind the cursor and can never come back.
+            # far behind its cursor and can never come back.
             for old in sorted(self.seen)[:256]:
                 self.seen.discard(old)
 
-    def parse_history(self, payload: dict):
-        """Returns (accepted, next_oldest). history comes back newest first."""
+    def parse_history(self, payload: dict, conversation=None):
+        """Returns (accepted, next_oldest). history comes back newest first.
+
+        Each accepted item is (user, reply_to, text). The user keys the
+        session; reply_to is (conversation, thread_ts) for a channel message
+        and (dm, None) for a DM, because a DM needs no thread to stay tidy.
+        """
+        conversation = self.channel if conversation is None else conversation
         accepted = []
-        oldest = self.oldest
+        oldest = self.cursors.get(conversation, self.started)
         messages = payload.get("messages") or []
         for message in reversed(messages):
             if not isinstance(message, dict):
@@ -794,9 +863,9 @@ class SlackAdapter(Adapter):
                     oldest = ts
             except ValueError:
                 continue
-            if ts in self.seen:
+            if (conversation, ts) in self.seen:
                 continue
-            self.remember(ts)
+            self.remember(conversation, ts)
             # The bridge's own replies come back through history. So do joins,
             # topic changes, and every other subtype.
             if message.get("bot_id") or message.get("subtype"):
@@ -809,32 +878,73 @@ class SlackAdapter(Adapter):
             text = message.get("text")
             if not isinstance(text, str) or not text.strip():
                 continue
-            accepted.append((self.channel, text.strip()))
+            if conversation == self.channel:
+                reply_to = (conversation, ts)
+            else:
+                reply_to = (conversation, None)
+            accepted.append((user, reply_to, text.strip()))
         return accepted, oldest
 
+    def poll_conversations(self):
+        """The conversations this pass reads: round-robin, one per pass.
+
+        Every pass is one history call, so N watched conversations cost the
+        same request rate as one and each is read every N * SLACK_POLL
+        seconds. conversations.history is a Slack Tier 3 method; reading all
+        of them every pass would trip its limit at three or four DMs.
+        """
+        if not self._poll_order:
+            self._poll_order = [self.channel] + sorted(self.dms)
+        return [self._poll_order.pop(0)]
+
     def poll_once(self) -> None:
-        payload = http_json(self.history_url(), headers=self.headers())
-        if not payload.get("ok", False):
-            # Slack reports failure in the body with HTTP 200. The error slug
-            # is a fixed vocabulary, never a token.
-            raise RuntimeError("slack api error: %s" % payload.get("error", "unknown"))
-        accepted, oldest = self.parse_history(payload)
-        self.oldest = oldest
-        for chat_id, text in accepted:
-            self.offer(chat_id, text)
+        if not self._dms_tried:
+            self.open_dms()
+        for conversation in self.poll_conversations():
+            payload = http_json(self.history_url(conversation), headers=self.headers())
+            if not payload.get("ok", False):
+                # Slack reports failure in the body with HTTP 200. The error
+                # slug is a fixed vocabulary, never a token.
+                raise RuntimeError(
+                    "slack api error: %s" % payload.get("error", "unknown")
+                )
+            accepted, oldest = self.parse_history(payload, conversation)
+            self.cursors[conversation] = oldest
+            for user, reply_to, text in accepted:
+                self.offer(user, text, reply_to=reply_to)
         time.sleep(SLACK_POLL)
 
-    def send_payloads(self, chat_id, text: str):
-        return [
-            (
-                "https://slack.com/api/chat.postMessage",
-                {"channel": self.channel, "text": chunk},
-            )
-            for chunk in split_message(text, self.limit)
-        ]
+    def thread_footer(self) -> str:
+        # The one thing a threaded answer must say: the bridge cannot read
+        # this thread, so a reply typed here goes nowhere.
+        if self.dms:
+            return "(I cannot see replies in this thread. DM me to continue.)"
+        return "(I cannot see replies in this thread. Post in the channel to continue.)"
 
-    def send(self, chat_id, text: str) -> None:
-        for url, payload in self.send_payloads(chat_id, text):
+    def split_reply_to(self, reply_to):
+        """(conversation, thread_ts) whatever shape the queue handed over.
+
+        A plain string arrives from the failure path in serve(), which sends
+        to whatever it was given; treat it as a conversation with no thread.
+        """
+        if isinstance(reply_to, tuple) and len(reply_to) == 2:
+            return reply_to
+        return (str(reply_to), None)
+
+    def send_payloads(self, reply_to, text: str):
+        conversation, thread_ts = self.split_reply_to(reply_to)
+        if thread_ts:
+            text = text.rstrip() + "\n\n" + self.thread_footer()
+        payloads = []
+        for chunk in split_message(text, self.limit):
+            body = {"channel": conversation, "text": chunk}
+            if thread_ts:
+                body["thread_ts"] = thread_ts
+            payloads.append(("https://slack.com/api/chat.postMessage", body))
+        return payloads
+
+    def send(self, reply_to, text: str) -> None:
+        for url, payload in self.send_payloads(reply_to, text):
             http_json(url, payload, headers=self.headers())
 
 
@@ -1271,7 +1381,7 @@ def serve(cfg: dict, helper: str, prompt_text: str, state_dir) -> int:
 
     search_root = expand_root(cfg["BRIDGE_CWD"])
     while True:
-        channel, chat_id, text = inbox.get()
+        channel, chat_id, reply_to, text = inbox.get()
         # The adapters are daemon threads, so an exception that escapes here
         # ends the process and takes them with it, silently. A full disk in
         # seed_workdir is not a reason to stop answering the other channels.
@@ -1283,7 +1393,7 @@ def serve(cfg: dict, helper: str, prompt_text: str, state_dir) -> int:
             reply = run_helper(cfg, helper, workdir, text)
             log("%s %s: %d bytes out" % (channel, chat_id, len(reply.encode("utf-8"))))
             try:
-                adapter.send(chat_id, reply)
+                adapter.send(reply_to, reply)
             except Exception as exc:  # noqa: BLE001 - a failed send is not fatal
                 log(
                     "%s %s: send failed (%s)"
@@ -1298,7 +1408,7 @@ def serve(cfg: dict, helper: str, prompt_text: str, state_dir) -> int:
             # them is best effort: whatever broke the turn may break this too.
             try:
                 adapters[channel].send(
-                    chat_id, "The lantern hit an error on that one. Try again."
+                    reply_to, "The lantern hit an error on that one. Try again."
                 )
             except Exception as exc2:  # noqa: BLE001 - never fatal
                 log(

--- a/bridge.conf.example
+++ b/bridge.conf.example
@@ -8,6 +8,11 @@
 # A channel turns on when its credential is set, and refuses to start until its
 # allowlist names who may talk to it.
 
+# Start the bridge with the Herdr server, in its own Herdr pane, so no
+# terminal has to stay open. "1", "yes", or "true"; anything else means the
+# bridge starts only when you open it yourself.
+BRIDGE_AUTOSTART=""
+
 # Headless helper CLI. claude or codex only -- they are the two with a real
 # one-shot mode that also resumes. Empty: the first of them on PATH.
 BRIDGE_HELPER=""

--- a/bridge.sh
+++ b/bridge.sh
@@ -53,15 +53,28 @@ if [ "${1:-}" = "--autostart" ]; then
     fi
     [ -n "$auto_config_dir" ] || exit 0
     [ -f "$auto_config_dir/bridge.conf" ] || exit 0
-    auto_value=$(sed -n 's/^BRIDGE_AUTOSTART=//p' "$auto_config_dir/bridge.conf" | sed -n '1p')
+    # Match the daemon's own parser, which strips the line before splitting on
+    # the first '=', so an indented key is valid config. Anchoring at column 0
+    # here made a line the daemon accepts invisible to this hook, and the
+    # symptom was a key that looks set and a bridge that never starts.
+    auto_value=$(sed -n 's/^[[:space:]]*BRIDGE_AUTOSTART[[:space:]]*=//p' \
+        "$auto_config_dir/bridge.conf" | sed -n '1p')
     # The conf writes values quoted; both quote styles count as the bare value.
+    auto_value=$(printf '%s' "$auto_value" | tr -d '[:space:]' | tr 'A-Z' 'a-z')
     auto_value=${auto_value%\"}
     auto_value=${auto_value#\"}
     auto_value=${auto_value%\'}
     auto_value=${auto_value#\'}
     case $auto_value in
     1 | yes | true) ;;
-    *) exit 0 ;;
+    '') exit 0 ;;
+    *)
+        # Set to something, but not something this understands. Silence here
+        # leaves nothing at all to diagnose from.
+        printf 'lantern bridge: BRIDGE_AUTOSTART=%s not understood; not starting. Use 1, yes, or true.\n' \
+            "$auto_value" >&2
+        exit 0
+        ;;
     esac
     set -- --open
 fi

--- a/bridge.sh
+++ b/bridge.sh
@@ -39,6 +39,33 @@ bridge_pane_title='Lantern Bridge'
 # the pane runs this file again without --open. The real herdr is called
 # directly here, the way open.sh does: the wrapper's gate is for the helper
 # CLI, not for the plugin's own entrypoints.
+# --autostart is the [[startup]] hook: Herdr runs it once after the server
+# comes up. It never seeds anything and it never becomes the daemon. When the
+# owner has written BRIDGE_AUTOSTART="1" into an existing bridge.conf, it
+# turns into --open, which seats the bridge pane inside Herdr; otherwise it
+# exits quietly, so the hook costs nothing on a machine that never configured
+# the bridge.
+if [ "${1:-}" = "--autostart" ]; then
+    auto_config_dir=${HERDR_PLUGIN_CONFIG_DIR:-}
+    if [ -z "$auto_config_dir" ]; then
+        auto_config_dir=$(herdr plugin config-dir aigora.lantern 2>/dev/null) ||
+            auto_config_dir=
+    fi
+    [ -n "$auto_config_dir" ] || exit 0
+    [ -f "$auto_config_dir/bridge.conf" ] || exit 0
+    auto_value=$(sed -n 's/^BRIDGE_AUTOSTART=//p' "$auto_config_dir/bridge.conf" | sed -n '1p')
+    # The conf writes values quoted; both quote styles count as the bare value.
+    auto_value=${auto_value%\"}
+    auto_value=${auto_value#\"}
+    auto_value=${auto_value%\'}
+    auto_value=${auto_value#\'}
+    case $auto_value in
+    1 | yes | true) ;;
+    *) exit 0 ;;
+    esac
+    set -- --open
+fi
+
 if [ "${1:-}" = "--open" ]; then
     real_herdr=${HERDR_BIN_PATH:-}
     case $real_herdr in

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.5.1 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.6.0 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>

--- a/docs/slack-trial.md
+++ b/docs/slack-trial.md
@@ -32,14 +32,19 @@ Go to [api.slack.com/apps](https://api.slack.com/apps) â†’ **Create New App** â†
 **From scratch**. Name it something the channel will recognise (`Lantern` is
 fine) and pick your workspace.
 
-In **OAuth & Permissions**, scroll to **Bot Token Scopes** and add exactly two:
+In **OAuth & Permissions**, scroll to **Bot Token Scopes** and add exactly
+four:
 
 | Scope | Why |
 | --- | --- |
 | `channels:history` | read the messages in the channel it watches |
 | `chat:write` | post its answers back |
+| `im:history` | read your DM with the bot, where a conversation continues |
+| `im:write` | open that DM |
 
-Add nothing else. The bridge uses no other Slack API.
+Add nothing else. The bridge uses no other Slack API. If you added scopes
+after installing the app, reinstall it from this same page; scope changes do
+not take effect until you do.
 
 If you plan to watch a **private** channel, use `groups:history` instead of
 `channels:history`. Everything else is the same.
@@ -165,6 +170,18 @@ the daemon, then send your test message.
 **It answers you and ignores everyone else.** Messages from anyone outside
 `SLACK_ALLOWED_USERS` are dropped, as are the bot's own messages and Slack's
 join/leave notices.
+
+**Channel answers land in a thread; the conversation lives in your DM.** A
+message in the channel is answered in its own thread, so the channel stays
+readable. Do not reply inside the thread: Slack's history API does not return
+thread replies, so the bridge cannot see them, and the threaded answer says
+so. Open the bot's DM instead and carry on there; it is the same conversation,
+because the session follows you rather than the room. The DM is also simply
+the better place to talk to it, phone included.
+
+**No terminal, if you want that.** Once the tokens are in `bridge.conf`
+rather than exported, set `BRIDGE_AUTOSTART="1"` in the same file and the
+Herdr server seats the bridge pane itself on startup.
 
 **Mutating Herdr still needs your confirmation.** Inspect commands run
 normally, but anything that creates, starts, focuses, closes, or prompts is

--- a/docs/slack-trial.md
+++ b/docs/slack-trial.md
@@ -46,6 +46,15 @@ Add nothing else. The bridge uses no other Slack API. If you added scopes
 after installing the app, reinstall it from this same page; scope changes do
 not take effect until you do.
 
+Then turn the DM on. Scopes alone do not do it: a Slack app cannot be sent a
+direct message until its Messages tab is enabled, and Slack shows either no
+message box at all or "Sending messages to this app has been turned off".
+
+Go to **App Home** in the left sidebar, find **Show Tabs**, switch on
+**Messages Tab**, and tick **Allow users to send Slash commands and messages
+from the messages tab**. This one is a setting rather than a scope, so it
+takes effect at once with no reinstall.
+
 If you plan to watch a **private** channel, use `groups:history` instead of
 `channels:history`. Everything else is the same.
 
@@ -207,6 +216,8 @@ cannot see any other conversation.
 | `missing_scope` in the log | A scope was added after installing. Re-install the app from **OAuth & Permissions**; scope changes need it. |
 | `a lantern bridge is already running` | One is. The message names the lock file. Stop that daemon first. |
 | `no bridge helper on PATH` | Neither `claude` nor `codex` is installed, or `BRIDGE_HELPER` names something else. |
+| You cannot type a DM to the bot | The Messages tab is off. **App Home** → **Show Tabs** → **Messages Tab**, plus the checkbox under it. Not a scope, so no reinstall. |
+| The DM never answers, but the channel does | The `im:history` and `im:write` scopes were added after the app was installed. Reinstall it. The bridge log names the missing scope. |
 
 The daemon logs one line per message with the channel, the sender, and a byte
 count. It never logs message text or any token, and an unexpected error inside

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,9 +1,14 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.5.1"
+version = "0.6.0"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]
+
+[[startup]]
+# One-shot: after the server is up, seat the bridge pane when the owner set
+# BRIDGE_AUTOSTART="1" in bridge.conf. Exits quietly otherwise.
+command = ["sh", "bridge.sh", "--autostart"]
 
 [[panes]]
 id = "helper"

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.5.1</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.6.0</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -338,6 +338,20 @@ class SplitMessageTest(unittest.TestCase):
     def test_empty_text_is_one_empty_chunk(self):
         self.assertEqual(lb.split_message("", 100), [""])
 
+    def test_interior_line_breaks_survive(self):
+        # A relayed list has to arrive as a list. Splitting cuts on newlines,
+        # so the risk is it eating the ones inside a chunk.
+        recipe = "Koftas\n1. Drain the tuna.\n2. Flake it.\n3. Chill it.\n"
+        self.assertEqual(lb.split_message(recipe, 4000), [recipe])
+        self.assertEqual(lb.split_message(recipe, 4000)[0].count("\n"), 4)
+
+    def test_line_breaks_survive_a_split_across_chunks(self):
+        block = "\n".join("%d. step" % n for n in range(1, 21))
+        chunks = lb.split_message(block, 40)
+        self.assertGreater(len(chunks), 1)
+        # Rejoining restores every line: nothing was flattened into a space.
+        self.assertEqual("\n".join(chunks).split("\n"), block.split("\n"))
+
     def test_every_chunk_respects_the_limit(self):
         text = ("word " * 400).strip()
         chunks = lb.split_message(text, 50)

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -352,6 +352,29 @@ class SplitMessageTest(unittest.TestCase):
         # Rejoining restores every line: nothing was flattened into a space.
         self.assertEqual("\n".join(chunks).split("\n"), block.split("\n"))
 
+    def test_blank_lines_and_indentation_survive_a_split(self):
+        # The appendix promises the helper that line breaks reach the chat app
+        # unchanged, so length is not a reason to condense a list. Stripping at
+        # the chunk boundary broke that promise for exactly the shaped content
+        # the instruction asks for: blank lines between steps vanished and
+        # indented continuation lines arrived flush left.
+        shaped = (
+            "1. first step\n"
+            "\n"
+            "2. second step\n"
+            "   - detail a\n"
+            "   - detail b\n"
+            "\n"
+            "3. third step\n"
+        )
+        chunks = lb.split_message(shaped, 30)
+        self.assertGreater(len(chunks), 1)
+        # Rejoining with the one separator that was removed gives the
+        # original back byte for byte, blank lines and indentation included.
+        self.assertEqual("\n".join(chunks), shaped)
+        self.assertTrue(any(c.startswith("   - detail a") or "\n   - detail a" in c
+                            for c in chunks), chunks)
+
     def test_every_chunk_respects_the_limit(self):
         text = ("word " * 400).strip()
         chunks = lb.split_message(text, 50)
@@ -753,7 +776,7 @@ class SlackParseTest(unittest.TestCase):
         accepted, oldest = self.parse([slack_message("1001.000100", "U1", " hi ")])
         # The session keys on the person; the reply goes to the message's
         # own thread, which is what keeps the channel readable.
-        self.assertEqual(accepted, [("U1", ("C123", "1001.000100"), "hi")])
+        self.assertEqual(accepted, [("U1", ("C123", "1001.000100", "U1"), "hi")])
         self.assertEqual(oldest, "1001.000100")
 
     def test_a_dm_replies_in_the_dm_with_no_thread(self):
@@ -762,7 +785,7 @@ class SlackParseTest(unittest.TestCase):
         accepted, oldest = self.parse(
             [slack_message("1001.000100", "U1", "still there?")], conversation="D77"
         )
-        self.assertEqual(accepted, [("U1", ("D77", None), "still there?")])
+        self.assertEqual(accepted, [("U1", ("D77", None, "U1"), "still there?")])
         self.assertEqual(oldest, "1001.000100")
         # The channel cursor did not move: cursors are per conversation.
         self.assertEqual(self.adapter.cursors["C123"], "1000.000000")
@@ -775,6 +798,72 @@ class SlackParseTest(unittest.TestCase):
             [slack_message("1002.000100", "U1", "two")], conversation="D77"
         )
         self.assertEqual(in_channel[0][0], in_dm[0][0])
+
+    def test_a_dm_that_cannot_be_read_is_dropped_and_named(self):
+        # im:write without im:history: the DM opens, then every read fails.
+        # Raising would retry forever with the reason discarded and take the
+        # channel's poll down each cycle.
+        self.adapter.dms["D77"] = "U1"
+        self.adapter.cursors["D77"] = "1000.000000"
+        self.adapter._poll_order = ["D77"]
+        lines = []
+        original = lb.log
+        lb.log = lines.append
+        self.addCleanup(setattr, lb, "log", original)
+        original_http = lb.http_json
+        lb.http_json = lambda *a, **k: {"ok": False, "error": "missing_scope"}
+        self.addCleanup(setattr, lb, "http_json", original_http)
+        original_sleep = lb.time.sleep
+        lb.time.sleep = lambda _s: None
+        self.addCleanup(setattr, lb.time, "sleep", original_sleep)
+
+        self.adapter.poll_once()
+
+        self.assertNotIn("D77", self.adapter.dms)
+        self.assertNotIn("D77", self.adapter.cursors)
+        self.assertTrue(any("missing_scope" in line for line in lines), lines)
+        self.assertTrue(any("im:history" in line for line in lines), lines)
+
+    def test_the_channel_failing_still_raises(self):
+        original_http = lb.http_json
+        lb.http_json = lambda *a, **k: {"ok": False, "error": "ratelimited"}
+        self.addCleanup(setattr, lb, "http_json", original_http)
+        self.adapter._poll_order = ["C123"]
+        with self.assertRaises(RuntimeError):
+            self.adapter.poll_once()
+
+    def test_dms_are_retried_after_a_blip_rather_than_given_up_on(self):
+        # A network failure at daemon start must not turn DMs off for the life
+        # of the process, and must not be reported as a missing scope.
+        calls = []
+        original_http = lb.http_json
+
+        def flaky(url, payload=None, headers=None, timeout=None):
+            calls.append(url)
+            # The allowlist holds two users, so one attempt is two calls.
+            if len(calls) <= 2:
+                raise OSError("network is down")
+            return {"ok": True, "channel": {"id": "D99"}}
+
+        lb.http_json = flaky
+        self.addCleanup(setattr, lb, "http_json", original_http)
+        original = lb.log
+        lb.log = lambda _m: None
+        self.addCleanup(setattr, lb, "log", original)
+
+        self.adapter.open_dms(now=0.0)
+        self.assertEqual(self.adapter.dms, {})
+        self.assertEqual(len(calls), 2)
+        # Too soon: nothing asked again.
+        self.adapter.open_dms(now=1.0)
+        self.assertEqual(len(calls), 2)
+        # After the retry window it asks again and succeeds.
+        self.adapter.open_dms(now=lb.DM_OPEN_RETRY + 1.0)
+        self.assertIn("D99", self.adapter.dms)
+        # Having opened one, it stops asking.
+        before = len(calls)
+        self.adapter.open_dms(now=lb.DM_OPEN_RETRY * 100)
+        self.assertEqual(len(calls), before)
 
     def test_dm_open_payload_shape(self):
         url, payload = self.adapter.dm_open_payload("U1")
@@ -835,6 +924,24 @@ class SlackParseTest(unittest.TestCase):
             self.adapter.remember("C123", "2000.%06d" % i)
         self.assertLessEqual(len(self.adapter.seen), 512)
 
+    def test_pruning_keeps_the_newest_of_every_conversation(self):
+        # The set holds (conversation, ts) pairs. Sorting the pairs sorts by
+        # conversation id first, so pruning that way evicts one conversation
+        # whole: channel ids start with C, DM ids with D, so a busy DM would
+        # wipe the channel including its newest entry, which is the cursor
+        # boundary. Losing that answers the same message twice.
+        for i in range(30):
+            self.adapter.remember("C123", "3000.%06d" % i)
+        for i in range(490):
+            self.adapter.remember("D777", "4000.%06d" % i)
+        self.adapter.remember("C123", "5000.000000")
+        for i in range(200):
+            self.adapter.remember("D777", "6000.%06d" % i)
+        self.assertLessEqual(len(self.adapter.seen), 512)
+        self.assertIn(("C123", "5000.000000"), self.adapter.seen)
+        survivors = {c for c, _ts in self.adapter.seen}
+        self.assertIn("C123", survivors)
+
     def test_garbage_payload_does_not_raise(self):
         startup = self.adapter.cursors["C123"]
         self.assertEqual(self.adapter.parse_history({}), ([], startup))
@@ -869,14 +976,25 @@ class SlackSendTest(unittest.TestCase):
         # the person replies into a hole.
         self.assertIn("cannot see replies in this thread", payload["text"])
 
-    def test_footer_points_at_the_dm_when_one_exists(self):
+    def test_footer_points_at_the_dm_when_that_person_has_one(self):
         self.adapter.dms["D77"] = "U1"
-        _url, payload = self.adapter.send_payloads(("C123", "1001.000100"), "hi")[0]
+        _url, payload = self.adapter.send_payloads(("C123", "1001.000100", "U1"), "hi")[0]
         self.assertIn("DM me to continue", payload["text"])
 
     def test_footer_points_at_the_channel_when_dms_are_unavailable(self):
-        _url, payload = self.adapter.send_payloads(("C123", "1001.000100"), "hi")[0]
+        _url, payload = self.adapter.send_payloads(("C123", "1001.000100", "U1"), "hi")[0]
         self.assertIn("Post in the channel to continue", payload["text"])
+
+    def test_footer_does_not_send_a_user_to_a_dm_that_is_not_theirs(self):
+        # open_dms carries on past a user whose DM will not open. Telling that
+        # person to DM would send them somewhere nothing is read.
+        self.adapter.dms["D77"] = "U1"
+        _url, payload = self.adapter.send_payloads(("C123", "1001.000100", "U2"), "hi")[0]
+        self.assertIn("Post in the channel to continue", payload["text"])
+
+    def test_a_two_part_reply_target_still_sends(self):
+        sends = self.adapter.send_payloads(("D77", None), "hi")
+        self.assertEqual(sends[0][1]["channel"], "D77")
 
     def test_a_plain_string_target_still_sends(self):
         # The failure path in serve() sends to whatever it was given.

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -710,7 +710,7 @@ class TelegramSendTest(unittest.TestCase):
         inbox = queue.Queue()
         cfg = base_config(TELEGRAM_BOT_TOKEN="tok", TELEGRAM_ALLOWED_CHATS="42")
         lb.TelegramAdapter(cfg, inbox).offer(42, "hi")
-        self.assertEqual(inbox.get_nowait(), ("telegram", "42", "hi"))
+        self.assertEqual(inbox.get_nowait(), ("telegram", "42", "42", "hi"))
 
 
 def slack_message(ts, user="U1", text="hello", **extra):
@@ -729,14 +729,48 @@ class SlackParseTest(unittest.TestCase):
         self.inbox = queue.Queue()
         self.adapter = lb.SlackAdapter(cfg, self.inbox, now=1000.0)
 
-    def parse(self, messages):
+    def parse(self, messages, conversation=None):
         # Slack returns history newest first.
-        return self.adapter.parse_history({"ok": True, "messages": list(reversed(messages))})
+        return self.adapter.parse_history(
+            {"ok": True, "messages": list(reversed(messages))}, conversation
+        )
 
     def test_allowed_user_is_accepted(self):
         accepted, oldest = self.parse([slack_message("1001.000100", "U1", " hi ")])
-        self.assertEqual(accepted, [("C123", "hi")])
+        # The session keys on the person; the reply goes to the message's
+        # own thread, which is what keeps the channel readable.
+        self.assertEqual(accepted, [("U1", ("C123", "1001.000100"), "hi")])
         self.assertEqual(oldest, "1001.000100")
+
+    def test_a_dm_replies_in_the_dm_with_no_thread(self):
+        self.adapter.dms["D77"] = "U1"
+        self.adapter.cursors["D77"] = "1000.000000"
+        accepted, oldest = self.parse(
+            [slack_message("1001.000100", "U1", "still there?")], conversation="D77"
+        )
+        self.assertEqual(accepted, [("U1", ("D77", None), "still there?")])
+        self.assertEqual(oldest, "1001.000100")
+        # The channel cursor did not move: cursors are per conversation.
+        self.assertEqual(self.adapter.cursors["C123"], "1000.000000")
+
+    def test_channel_and_dm_share_one_session_key(self):
+        self.adapter.dms["D77"] = "U1"
+        self.adapter.cursors["D77"] = "1000.000000"
+        in_channel, _ = self.parse([slack_message("1001.000100", "U1", "one")])
+        in_dm, _ = self.parse(
+            [slack_message("1002.000100", "U1", "two")], conversation="D77"
+        )
+        self.assertEqual(in_channel[0][0], in_dm[0][0])
+
+    def test_dm_open_payload_shape(self):
+        url, payload = self.adapter.dm_open_payload("U1")
+        self.assertEqual(url, "https://slack.com/api/conversations.open")
+        self.assertEqual(payload, {"users": "U1"})
+
+    def test_poll_order_round_robins_the_channel_and_every_dm(self):
+        self.adapter.dms = {"D1": "U1", "D2": "U2"}
+        seen = [self.adapter.poll_conversations()[0] for _ in range(6)]
+        self.assertEqual(seen, ["C123", "D1", "D2", "C123", "D1", "D2"])
 
     def test_own_bot_message_is_skipped(self):
         accepted, oldest = self.parse(
@@ -766,32 +800,33 @@ class SlackParseTest(unittest.TestCase):
         )
         # Oldest first, whichever order Slack listed them in, and the cursor
         # clears the dropped message too.
-        self.assertEqual([t for _c, t in accepted], ["one", "two"])
+        self.assertEqual([t for _u, _r, t in accepted], ["one", "two"])
         self.assertEqual(oldest, "1003.000100")
 
     def test_a_replayed_message_is_not_answered_twice(self):
         message = slack_message("1001.000100", "U1", "hi")
         self.assertEqual(len(self.parse([message])[0]), 1)
-        self.adapter.oldest = "1000.000000"
+        self.adapter.cursors["C123"] = "1000.000000"
         self.assertEqual(self.parse([message])[0], [])
 
     def test_messages_before_startup_never_arrive(self):
         # The cursor is sent to Slack, so old history is not returned at all;
         # this pins the cursor's initial value, which is what does that.
-        self.assertEqual(self.adapter.oldest, "%.6f" % 1000.0)
+        self.assertEqual(self.adapter.cursors["C123"], "%.6f" % 1000.0)
         self.assertIn("oldest=1000.000000", self.adapter.history_url())
         self.assertIn("channel=C123", self.adapter.history_url())
 
     def test_seen_set_stays_bounded(self):
         for i in range(700):
-            self.adapter.remember("2000.%06d" % i)
+            self.adapter.remember("C123", "2000.%06d" % i)
         self.assertLessEqual(len(self.adapter.seen), 512)
 
     def test_garbage_payload_does_not_raise(self):
-        self.assertEqual(self.adapter.parse_history({}), ([], self.adapter.oldest))
+        startup = self.adapter.cursors["C123"]
+        self.assertEqual(self.adapter.parse_history({}), ([], startup))
         self.assertEqual(
             self.adapter.parse_history({"messages": [None, {"ts": "nope"}]}),
-            ([], self.adapter.oldest),
+            ([], startup),
         )
 
 
@@ -804,7 +839,33 @@ class SlackSendTest(unittest.TestCase):
         )
         self.adapter = lb.SlackAdapter(cfg, queue.Queue(), now=1000.0)
 
-    def test_payload_shape(self):
+    def test_dm_payload_shape(self):
+        sends = self.adapter.send_payloads(("D77", None), "hi")
+        self.assertEqual(
+            sends, [("https://slack.com/api/chat.postMessage", {"channel": "D77", "text": "hi"})]
+        )
+
+    def test_channel_reply_lands_in_the_thread(self):
+        sends = self.adapter.send_payloads(("C123", "1001.000100"), "hi")
+        self.assertEqual(len(sends), 1)
+        _url, payload = sends[0]
+        self.assertEqual(payload["channel"], "C123")
+        self.assertEqual(payload["thread_ts"], "1001.000100")
+        # A threaded answer must say the bridge cannot read the thread, or
+        # the person replies into a hole.
+        self.assertIn("cannot see replies in this thread", payload["text"])
+
+    def test_footer_points_at_the_dm_when_one_exists(self):
+        self.adapter.dms["D77"] = "U1"
+        _url, payload = self.adapter.send_payloads(("C123", "1001.000100"), "hi")[0]
+        self.assertIn("DM me to continue", payload["text"])
+
+    def test_footer_points_at_the_channel_when_dms_are_unavailable(self):
+        _url, payload = self.adapter.send_payloads(("C123", "1001.000100"), "hi")[0]
+        self.assertIn("Post in the channel to continue", payload["text"])
+
+    def test_a_plain_string_target_still_sends(self):
+        # The failure path in serve() sends to whatever it was given.
         sends = self.adapter.send_payloads("C123", "hi")
         self.assertEqual(
             sends, [("https://slack.com/api/chat.postMessage", {"channel": "C123", "text": "hi"})]
@@ -816,10 +877,12 @@ class SlackSendTest(unittest.TestCase):
 
     def test_long_reply_is_split_at_the_slack_limit(self):
         text = "\n".join(["y" * 200] * 60)
-        sends = self.adapter.send_payloads("C123", text)
+        sends = self.adapter.send_payloads(("C123", "1001.000100"), text)
         self.assertGreater(len(sends), 1)
         for _url, payload in sends:
             self.assertLessEqual(len(payload["text"]), lb.SLACK_LIMIT)
+            # Every chunk of a threaded reply stays in the thread.
+            self.assertEqual(payload["thread_ts"], "1001.000100")
 
 
 WHATSAPP_SECRET = "app-secret-value"
@@ -1019,7 +1082,8 @@ class WhatsAppWebhookTest(unittest.TestCase):
         status, _body = self.post(raw, sign(raw))
         self.assertEqual(status, 200)
         self.assertEqual(
-            self.inbox.get(timeout=5), ("whatsapp", "15551234567", "light the field")
+            self.inbox.get(timeout=5),
+            ("whatsapp", "15551234567", "15551234567", "light the field"),
         )
 
     def test_bad_signature_is_401_and_enqueues_nothing(self):
@@ -1368,8 +1432,8 @@ class DispatchLoopTest(unittest.TestCase):
         worker.start()
         self.assertTrue(started.wait(10), "the adapter thread never started")
         inbox = captured[0].inbox
-        inbox.put(("telegram", "1", "first"))
-        inbox.put(("telegram", "1", "second"))
+        inbox.put(("telegram", "1", "1", "first"))
+        inbox.put(("telegram", "1", "1", "second"))
         self.assertTrue(answered.wait(10), "the loop died on the first message")
         self.assertTrue(worker.is_alive())
         # The first turn failed before its reply, so the user hears about it.

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -27,8 +27,9 @@ fake_agents=
 argv_dir=
 open_dir=
 bridge_dir=
+autostart_dir=
 elves_tmp=
-trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$fake_cmd" ] && rm -rf "$fake_cmd"; [ -n "$fake_py" ] && rm -rf "$fake_py"; [ -n "$fake_agents" ] && rm -rf "$fake_agents"; [ -n "$argv_dir" ] && rm -rf "$argv_dir"; [ -n "$open_dir" ] && rm -rf "$open_dir"; [ -n "$bridge_dir" ] && rm -rf "$bridge_dir"; [ -n "$elves_tmp" ] && rm -rf "$elves_tmp"' EXIT
+trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$fake_cmd" ] && rm -rf "$fake_cmd"; [ -n "$fake_py" ] && rm -rf "$fake_py"; [ -n "$fake_agents" ] && rm -rf "$fake_agents"; [ -n "$argv_dir" ] && rm -rf "$argv_dir"; [ -n "$open_dir" ] && rm -rf "$open_dir"; [ -n "$bridge_dir" ] && rm -rf "$bridge_dir"; [ -n "$autostart_dir" ] && rm -rf "$autostart_dir"; [ -n "$elves_tmp" ] && rm -rf "$elves_tmp"' EXIT
 
 printf '%s\n' 'HELPER_AGENT="devin"' 'HELPER_SPAWN_KIND="claude"' >"$tmp"
 HELPER_AGENT=""
@@ -1271,5 +1272,60 @@ unset BRIDGE_STUB_LOG
 rm -rf "$bridge_dir"
 bridge_dir=
 printf 'ok: bridge.sh config gate and redacted --check\n'
+
+# --autostart is the [[startup]] hook. It must cost nothing when nothing is
+# configured, and it must not become the daemon itself: it turns into --open,
+# which asks herdr to seat the bridge pane. The stub herdr records the ask.
+autostart_dir=$(mktemp -d)
+mkdir -p "$autostart_dir/config" "$autostart_dir/bin"
+cat >"$autostart_dir/bin/herdr" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$AUTOSTART_LOG"
+if [ "$1 $2 $3" = "plugin pane open" ]; then
+    printf '{"result":{"plugin_pane":{"pane":{"label":"Lantern Bridge","pane_id":"w1:p9","scroll":{"viewport_rows":32},"tab_id":"w1:t9","workspace_id":"w1"}}}}\n'
+fi
+exit 0
+EOF
+chmod +x "$autostart_dir/bin/herdr"
+AUTOSTART_LOG=$autostart_dir/calls.txt
+export AUTOSTART_LOG
+: >"$AUTOSTART_LOG"
+
+run_autostart() {
+    HERDR_PLUGIN_ROOT="$root" \
+        HERDR_PLUGIN_CONFIG_DIR="$autostart_dir/config" \
+        HERDR_PLUGIN_STATE_DIR="$autostart_dir/state" \
+        HERDR_BIN_PATH="$autostart_dir/bin/herdr" \
+        sh "$root/bridge.sh" --autostart </dev/null >/dev/null 2>&1
+}
+
+# No config file at all: exit 0, call nothing, seed nothing.
+run_autostart || fail "autostart with no config should exit 0"
+if [ -s "$AUTOSTART_LOG" ]; then
+    fail "autostart with no config must not call herdr"
+fi
+if [ -f "$autostart_dir/config/bridge.conf" ]; then
+    fail "autostart must never seed bridge.conf"
+fi
+
+# Config present but the key off: still nothing.
+printf '%s\n' 'BRIDGE_AUTOSTART=""' >"$autostart_dir/config/bridge.conf"
+run_autostart || fail "autostart with the key off should exit 0"
+if [ -s "$AUTOSTART_LOG" ]; then
+    fail "autostart with the key off must not call herdr"
+fi
+
+# Key on: it asks herdr to seat the bridge pane, and does not run the daemon.
+printf '%s\n' 'BRIDGE_AUTOSTART="1"' >"$autostart_dir/config/bridge.conf"
+run_autostart || fail "autostart with the key on should succeed"
+grep -q 'plugin pane open --plugin aigora.lantern --entrypoint bridge' \
+    "$AUTOSTART_LOG" || fail "autostart should open the bridge pane"
+
+# The manifest wires the hook, or none of this ever runs.
+grep -q -- '"--autostart"' "$root/herdr-plugin.toml" ||
+    fail "manifest should carry the autostart startup hook"
+rm -rf "$autostart_dir"
+autostart_dir=
+printf 'ok: bridge.sh autostart gate\n'
 
 printf 'ok\n'

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1321,6 +1321,39 @@ run_autostart || fail "autostart with the key on should succeed"
 grep -q 'plugin pane open --plugin aigora.lantern --entrypoint bridge' \
     "$AUTOSTART_LOG" || fail "autostart should open the bridge pane"
 
+# An indented key is valid config to the daemon, whose parser strips the line
+# before splitting on '='. A hook that anchors at column 0 makes such a line
+# invisible, and the symptom is a key that looks set and a bridge that never
+# starts, with nothing logged.
+printf '%s\n' '  BRIDGE_AUTOSTART="1"' >"$autostart_dir/config/bridge.conf"
+: >"$AUTOSTART_LOG"
+run_autostart || fail "autostart should accept an indented key"
+grep -q 'plugin pane open' "$AUTOSTART_LOG" ||
+    fail "autostart should open the bridge pane for an indented key"
+
+# Case is the user's business, not the parser's.
+printf '%s\n' 'BRIDGE_AUTOSTART="True"' >"$autostart_dir/config/bridge.conf"
+: >"$AUTOSTART_LOG"
+run_autostart || fail "autostart should accept True"
+grep -q 'plugin pane open' "$AUTOSTART_LOG" ||
+    fail "autostart should open the bridge pane for True"
+
+# Set to something it does not understand: no start, but say why.
+printf '%s\n' 'BRIDGE_AUTOSTART="maybe"' >"$autostart_dir/config/bridge.conf"
+: >"$AUTOSTART_LOG"
+autostart_err=$autostart_dir/err.txt
+HERDR_PLUGIN_ROOT="$root" \
+    HERDR_PLUGIN_CONFIG_DIR="$autostart_dir/config" \
+    HERDR_PLUGIN_STATE_DIR="$autostart_dir/state" \
+    HERDR_BIN_PATH="$autostart_dir/bin/herdr" \
+    sh "$root/bridge.sh" --autostart </dev/null >/dev/null 2>"$autostart_err" ||
+    fail "an unrecognised autostart value should still exit 0"
+if [ -s "$AUTOSTART_LOG" ]; then
+    fail "an unrecognised autostart value must not call herdr"
+fi
+grep -q 'not understood' "$autostart_err" ||
+    fail "an unrecognised autostart value should say so"
+
 # The manifest wires the hook, or none of this ever runs.
 grep -q -- '"--autostart"' "$root/herdr-plugin.toml" ||
     fail "manifest should carry the autostart startup hook"


### PR DESCRIPTION
Trial feedback: replies cluttered the channel, and a terminal had to stay
open for the bridge.

## Replies follow the message, the session follows the person

A channel message is answered in its own thread, so the channel stays
readable. The bridge also opens and polls each allowlisted member's DM with
the bot, and a DM is answered in the DM. Both places share one conversation
per person, so a question asked in the channel continues in the DM without
starting over.

Threads are reply-only: `conversations.history` does not return thread
replies, so the bridge cannot see anything typed inside one. Every threaded
answer carries a line saying so and where to continue instead.

Needs two new bot scopes, `im:history` and `im:write`, and an app reinstall.
Without them the bridge names the missing scope and runs channel-only, so an
existing install keeps working after upgrade.

Polling is round-robin, one conversation per pass, so watching the DMs costs
the same request rate as watching the channel alone against Slack's Tier 3
limit.

## No terminal for the bridge

`BRIDGE_AUTOSTART="1"` in `bridge.conf` makes a `[[startup]]` hook seat the
bridge pane when the Herdr server comes up. The hook reads the config file
only, exits quietly when the key is off or the file is absent, and never
seeds anything. Autostart requires the tokens to live in `bridge.conf`
(created 0600) rather than in an exported variable, which no longer exists by
the time the server boots.

## Brevity

The remote appendix now says two or three short sentences is the normal
reply, detail only on request, no restating the question.

## Mechanics

Queue items carry a reply target separate from the conversation key. Telegram
and WhatsApp pass the same value for both and are unchanged. Slack sessions
were keyed by the channel and are now keyed by the member id, so one existing
conversation starts fresh on upgrade.

## Tests

137 bridge unit tests green, including thread payloads, the footer with and
without DMs, DM parsing, the shared session key, round-robin order, and
per-conversation cursors. The smoke suite gains the autostart gate and is
green on Windows; CI runs it on all three platforms.

Not verified against a live workspace: the shape `conversations.open` returns.
One message in the trial channel answers that.
