### PR TITLE
Bridge fixes before public handoff: dead pane, DM latency, WhatsApp redelivery

### DIFF
--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -83,6 +83,9 @@ UNSAFE_CHARS = "$`;|&<>(){}"
 # Per-channel outbound limits, from each provider's documented maximum.
 TELEGRAM_LIMIT = 4096
 SLACK_LIMIT = 4000
+# How many WhatsApp message ids to remember. Meta retries within minutes,
+# so this only has to outlast a retry window.
+WHATSAPP_SEEN_MAX = 512
 WHATSAPP_LIMIT = 4096
 
 # A headless turn can legitimately run for minutes; it is still bounded.
@@ -96,6 +99,19 @@ SLACK_POLL = 3.0
 # Slack rates conversations.history at Tier 3, about 50 requests a minute. Kept
 # under that so every watched conversation can be read on every pass.
 SLACK_TIER3_BUDGET = 45.0
+# Slack errors that will not fix themselves, so a DM returning one is retired
+# rather than retried. Everything else, rate limits included, is transient.
+SLACK_PERMANENT_ERRORS = frozenset(
+    {
+        "missing_scope",
+        "not_allowed_token_type",
+        "channel_not_found",
+        "not_in_channel",
+        "invalid_auth",
+        "account_inactive",
+        "token_revoked",
+    }
+)
 # How long to wait before asking Slack to open the DMs again, when the last
 # attempt opened none.
 DM_OPEN_RETRY = 60.0
@@ -954,6 +970,18 @@ class SlackAdapter(Adapter):
     def poll_once(self) -> None:
         self.open_dms()
         watched = self.poll_conversations()
+        # The sleep is in a finally because it is the rate limit, not a
+        # courtesy. http_json raises on 429 and on timeouts, and the channel
+        # error path raises too; leaving the sleep on the clean path only meant
+        # a failing bridge fell back to Adapter.run's five second backoff and
+        # sent len(watched) requests every five seconds, which is several times
+        # the budget this interval exists to hold.
+        try:
+            self._poll_watched(watched)
+        finally:
+            time.sleep(self.poll_interval(watched))
+
+    def _poll_watched(self, watched) -> None:
         for conversation in watched:
             payload = http_json(self.history_url(conversation), headers=self.headers())
             if not payload.get("ok", False):
@@ -961,6 +989,16 @@ class SlackAdapter(Adapter):
                 # slug is a fixed vocabulary, never a token, so it is safe to
                 # log and it is the only thing that names the cause.
                 slug = payload.get("error", "unknown")
+                if conversation in self.dms and slug not in SLACK_PERMANENT_ERRORS:
+                    # Transient: rate limits and Slack faults come back. Now
+                    # that every watched conversation is read on every pass, a
+                    # single bad window would otherwise retire every DM at
+                    # once, and open_dms never reopens one after its first
+                    # success, so the bridge would run channel-only until
+                    # somebody restarted it.
+                    log("slack: could not read the DM for %s (%s); will try again"
+                        % (self.dms[conversation], slug))
+                    continue
                 if conversation in self.dms:
                     # A DM that opens but cannot be read is the shape of
                     # im:write granted without im:history. Raising here would
@@ -979,7 +1017,6 @@ class SlackAdapter(Adapter):
             self.cursors[conversation] = oldest
             for user, reply_to, text in accepted:
                 self.offer(user, text, reply_to=reply_to)
-        time.sleep(self.poll_interval(watched))
 
     def thread_footer(self, user=None) -> str:
         # The one thing a threaded answer must say: the bridge cannot read
@@ -1177,7 +1214,19 @@ class WhatsAppAdapter(Adapter):
         # would otherwise run the helper twice and send two replies, consuming
         # the single worker twice on the way. Telegram dedupes with its offset
         # and Slack with a seen set; this is WhatsApp's.
-        self.seen = set()
+        #
+        # A dict rather than a set, because eviction has to drop the oldest and
+        # a wamid carries no order to sort by. Slack's ids are timestamps and
+        # can be sorted; sorting these would evict arbitrary entries, including
+        # one that arrived a second ago, and Meta's retry of that one would run
+        # the helper twice, which is the bug this exists to prevent.
+        self.seen = {}
+        # Webhook bodies arrive on ThreadingHTTPServer worker threads, so the
+        # check and the add have to be one step. Two overlapping deliveries of
+        # one id would otherwise both pass the check, and a resize during
+        # iteration would raise out of do_POST, costing Meta its 200 and
+        # earning another retry.
+        self._seen_lock = threading.Lock()
         if not self.verify_token:
             raise ConfigError(
                 "WHATSAPP_VERIFY_TOKEN is required: compare_digest of two empty "
@@ -1263,21 +1312,37 @@ class WhatsAppAdapter(Adapter):
         return found
 
     def remember(self, message_id: str) -> None:
-        self.seen.add(message_id)
-        if len(self.seen) > 512:
-            # Bounded on purpose: this runs for weeks. Meta retries within
-            # minutes, so anything this old will not come back.
-            for old in sorted(self.seen)[:256]:
-                self.seen.discard(old)
+        """Record an id, dropping the oldest when the record is full."""
+        with self._seen_lock:
+            self._remember_locked(message_id)
+
+    def _remember_locked(self, message_id: str) -> None:
+        self.seen[message_id] = None
+        # Bounded on purpose: this runs for weeks. Meta retries within minutes,
+        # so the oldest entries can never come back. Insertion order is what
+        # makes "oldest" meaningful here.
+        while len(self.seen) > WHATSAPP_SEEN_MAX:
+            self.seen.pop(next(iter(self.seen)))
+
+    def seen_before(self, message_id: str) -> bool:
+        """True when this id has already been taken. Records it if not.
+
+        One step under the lock: a check followed by a separate add lets two
+        threads carrying the same redelivery both decide they are first.
+        """
+        with self._seen_lock:
+            if message_id in self.seen:
+                return True
+            self._remember_locked(message_id)
+            return False
 
     def accepted_from(self, payload: dict):
         accepted = []
         for message_id, sender, text in self.extract_messages(payload):
             if message_id:
-                if message_id in self.seen:
+                if self.seen_before(message_id):
                     log("whatsapp: skipped a redelivered message")
                     continue
-                self.remember(message_id)
             if only_digits(sender) not in self.allowed:
                 log("whatsapp: dropped a message from an unlisted number")
                 continue

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -1594,6 +1594,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--prompt", default="", help="path to the lantern prompt")
     parser.add_argument("--state", default=".", help="plugin state directory")
     parser.add_argument(
+        "--daemon-running",
+        action="store_true",
+        help="exit 0 when a bridge daemon holds the lock, 1 when none does",
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help="validate the config and print a redacted summary, then exit",
@@ -1612,8 +1617,50 @@ def die(message: str) -> None:
     raise SystemExit(2)
 
 
+def daemon_running(state_dir) -> bool:
+    """True when another process holds the daemon lock.
+
+    Taking the lock and dropping it is the only honest test. The lock is
+    advisory and the kernel releases it when a process dies, so the file
+    outliving its daemon proves nothing, and the pid written inside can belong
+    to something else entirely after a reboot. Closing the descriptor releases
+    the lock on both platforms, which the finally below does either way.
+    """
+    try:
+        fd = os.open(str(daemon_lock_path(state_dir)), os.O_RDWR | os.O_CREAT, 0o600)
+    except OSError:
+        # Nothing to lock in means nothing is running in it.
+        return False
+    try:
+        taken = _take_lock(fd)
+        if taken is None:
+            # No locking primitive on this Python. Refusing to answer beats
+            # answering wrongly in either direction: a false "running" leaves
+            # a dead pane focused forever, a false "not running" seats a
+            # second daemon that fights the first over every message.
+            raise ConfigError(
+                "cannot tell whether a bridge is running: this Python has "
+                "neither fcntl nor msvcrt"
+            )
+        return not taken
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
+    if args.daemon_running:
+        # Asked before the config is read on purpose: whether a daemon holds
+        # the lock has nothing to do with whether bridge.conf parses, and
+        # `bridge.sh --open` has to be able to ask while the config is broken.
+        try:
+            return 0 if daemon_running(args.state) else 1
+        except ConfigError as exc:
+            die(str(exc))
+            return 2
     conf_path = Path(args.conf) if args.conf else None
     example_path = Path(args.example) if args.example else None
     try:

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -966,6 +966,12 @@ class SlackAdapter(Adapter):
     def drop_conversation(self, conversation: str) -> None:
         self.dms.pop(conversation, None)
         self.cursors.pop(conversation, None)
+        if not self.dms:
+            # The last DM is gone, usually to a scope error whose remedy is a
+            # reinstall of the Slack app. open_dms stops asking once it has
+            # opened one, so without this the fix would take effect only at
+            # the next daemon restart, and nothing would say so.
+            self._dms_next_try = time.time() + DM_OPEN_RETRY
 
     def poll_once(self) -> None:
         self.open_dms()
@@ -1008,7 +1014,8 @@ class SlackAdapter(Adapter):
                     log(
                         "slack: no longer reading the DM for %s (%s); "
                         "reading a DM needs the im:history scope and an app "
-                        "reinstall" % (self.dms[conversation], slug)
+                        "reinstall, then a bridge restart"
+                        % (self.dms[conversation], slug)
                     )
                     self.drop_conversation(conversation)
                     continue
@@ -1448,6 +1455,40 @@ def _take_lock(fd):
     return True
 
 
+def _release_lock(fd) -> None:
+    """Undo _take_lock before closing the descriptor.
+
+    Closing the handle releases the lock on both platforms eventually, but
+    Windows documents that a byte-range lock released by handle close may not
+    be released immediately. The probe in daemon_running runs moments before
+    a fresh daemon tries to take this same lock, and a delayed release would
+    kill that daemon with "already running" and no retry, so the probe lets
+    go explicitly.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        fcntl = None
+    if fcntl is not None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        return
+    try:
+        import msvcrt
+    except ImportError:
+        return
+    try:
+        os.lseek(fd, LOCK_BYTE_OFFSET, os.SEEK_SET)
+        try:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+    finally:
+        os.lseek(fd, 0, os.SEEK_SET)
+
+
 def acquire_daemon_lock(state_dir):
     """One bridge per state directory. Returns the fd to hold, or None.
 
@@ -1465,6 +1506,13 @@ def acquire_daemon_lock(state_dir):
     path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o600)
     taken = _take_lock(fd)
+    if taken is False:
+        # The holder can be the --open probe, which takes this lock for a
+        # moment to ask whether a daemon is running and lets go straight
+        # after. Dying on that instant would end a daemon whose own pane was
+        # seated a second ago, so give the holder one moment to finish.
+        time.sleep(0.2)
+        taken = _take_lock(fd)
     if taken is None:
         os.close(fd)
         log(
@@ -1707,7 +1755,12 @@ def daemon_running(state_dir) -> bool:
                 "cannot tell whether a bridge is running: this Python has "
                 "neither fcntl nor msvcrt"
             )
-        return not taken
+        if taken:
+            # Held only to answer the question. Let go before the close, or
+            # a daemon started moments from now can find it still held.
+            _release_lock(fd)
+            return False
+        return True
     finally:
         try:
             os.close(fd)

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -93,6 +93,9 @@ HELPER_TIMEOUT = 900
 TELEGRAM_POLL = 50
 # Slack has no long poll on this endpoint, so it is a plain interval.
 SLACK_POLL = 3.0
+# Slack rates conversations.history at Tier 3, about 50 requests a minute. Kept
+# under that so every watched conversation can be read on every pass.
+SLACK_TIER3_BUDGET = 45.0
 # How long to wait before asking Slack to open the DMs again, when the last
 # attempt opened none.
 DM_OPEN_RETRY = 60.0
@@ -805,7 +808,6 @@ class SlackAdapter(Adapter):
         # Herdr autostarting before DHCP) would otherwise turn DMs off for the
         # life of the process and report it as a missing scope.
         self._dms_next_try = 0.0
-        self._poll_order = []
 
     def headers(self) -> dict:
         return {"Authorization": "Bearer %s" % self.token}
@@ -926,25 +928,33 @@ class SlackAdapter(Adapter):
         return accepted, oldest
 
     def poll_conversations(self):
-        """The conversations this pass reads: round-robin, one per pass.
+        """Every conversation this bridge watches. The channel, then the DMs."""
+        return [self.channel] + sorted(self.dms)
 
-        Every pass is one history call, so N watched conversations cost the
-        same request rate as one and each is read every N * SLACK_POLL
-        seconds. conversations.history is a Slack Tier 3 method; reading all
-        of them every pass would trip its limit at three or four DMs.
+    def poll_interval(self, watched) -> float:
+        """Seconds to wait after reading them all.
+
+        The rate limit is held by slowing the pass, not by reading fewer
+        conversations per pass. Reading one at a time made each conversation
+        wait len(watched) intervals before anyone looked at it; reading them
+        all and stretching the interval makes every conversation wait exactly
+        one, for the same number of requests a minute.
+
+        Slack rates conversations.history at Tier 3, about 50 a minute.
         """
-        if not self._poll_order:
-            self._poll_order = [self.channel] + sorted(self.dms)
-        return [self._poll_order.pop(0)]
+        per_second = SLACK_TIER3_BUDGET / 60.0
+        if per_second <= 0:
+            return SLACK_POLL
+        return max(SLACK_POLL, len(watched) / per_second)
 
     def drop_conversation(self, conversation: str) -> None:
         self.dms.pop(conversation, None)
         self.cursors.pop(conversation, None)
-        self._poll_order = [c for c in self._poll_order if c != conversation]
 
     def poll_once(self) -> None:
         self.open_dms()
-        for conversation in self.poll_conversations():
+        watched = self.poll_conversations()
+        for conversation in watched:
             payload = http_json(self.history_url(conversation), headers=self.headers())
             if not payload.get("ok", False):
                 # Slack reports failure in the body with HTTP 200. The error
@@ -969,7 +979,7 @@ class SlackAdapter(Adapter):
             self.cursors[conversation] = oldest
             for user, reply_to, text in accepted:
                 self.offer(user, text, reply_to=reply_to)
-        time.sleep(SLACK_POLL)
+        time.sleep(self.poll_interval(watched))
 
     def thread_footer(self, user=None) -> str:
         # The one thing a threaded answer must say: the bridge cannot read
@@ -1161,8 +1171,13 @@ class WhatsAppAdapter(Adapter):
         self.host = cfg["WHATSAPP_WEBHOOK_HOST"] or "127.0.0.1"
         self.port = int(cfg["WHATSAPP_WEBHOOK_PORT"] or 8787)
         self.server = None
-        # These three are re-checked here, not only in validate(), because this
-        # object is the thing that opens a socket to the internet.
+        # Meta documents webhook delivery as at-least-once and retries anything
+        # it does not see acknowledged quickly. This bridge answers before the
+        # helper has finished, which keeps Meta happy, so a real redelivery
+        # would otherwise run the helper twice and send two replies, consuming
+        # the single worker twice on the way. Telegram dedupes with its offset
+        # and Slack with a seen set; this is WhatsApp's.
+        self.seen = set()
         if not self.verify_token:
             raise ConfigError(
                 "WHATSAPP_VERIFY_TOKEN is required: compare_digest of two empty "
@@ -1241,12 +1256,28 @@ class WhatsAppAdapter(Adapter):
                         continue
                     if not text.strip():
                         continue
-                    found.append((sender, text.strip()))
+                    message_id = message.get("id")
+                    if not isinstance(message_id, str):
+                        message_id = ""
+                    found.append((message_id, sender, text.strip()))
         return found
+
+    def remember(self, message_id: str) -> None:
+        self.seen.add(message_id)
+        if len(self.seen) > 512:
+            # Bounded on purpose: this runs for weeks. Meta retries within
+            # minutes, so anything this old will not come back.
+            for old in sorted(self.seen)[:256]:
+                self.seen.discard(old)
 
     def accepted_from(self, payload: dict):
         accepted = []
-        for sender, text in self.extract_messages(payload):
+        for message_id, sender, text in self.extract_messages(payload):
+            if message_id:
+                if message_id in self.seen:
+                    log("whatsapp: skipped a redelivered message")
+                    continue
+                self.remember(message_id)
             if only_digits(sender) not in self.allowed:
                 log("whatsapp: dropped a message from an unlisted number")
                 continue

--- a/bridge.sh
+++ b/bridge.sh
@@ -95,7 +95,46 @@ if [ "${1:-}" = "--open" ]; then
     # the cheap half, so a second press focuses instead of racing for it.
     open_state_dir=${HERDR_PLUGIN_STATE_DIR:-${HERDR_PLUGIN_CONFIG_DIR:-$plugin_root}/state}
     bridge_pane_file=$open_state_dir/bridge/pane.id
-    if [ -f "$bridge_pane_file" ]; then
+
+    # A remembered pane is only worth focusing while a daemon is alive in it.
+    # The title check below cannot tell: a pane whose daemon died keeps its
+    # title, so every later open focused a dead window and started nothing,
+    # with no way to tell from outside that anything was wrong. Ask the lock
+    # instead, which is the one thing only a live daemon holds.
+    #
+    # The path itself stays set either way: the open below records the new
+    # pane id in it.
+    bridge_daemon_alive=1
+    open_python=$(helper_detect_python) || open_python=
+    if [ -n "$open_python" ]; then
+        # shellcheck disable=SC2086
+        $open_python "$plugin_root/bin/lantern-bridge" \
+            --daemon-running --state "$open_state_dir" >/dev/null 2>&1 ||
+            bridge_daemon_alive=0
+    fi
+    if [ "$bridge_daemon_alive" = 0 ] && [ -f "$bridge_pane_file" ]; then
+        # An unheld lock is not proof of death. Herdr has to start bridge.sh
+        # in the pane this file records, and that takes a moment, so a second
+        # press during startup would otherwise seat a duplicate. Inside the
+        # grace window, treat the pane as coming up.
+        if [ -n "$(find "$bridge_pane_file" -mmin -2 2>/dev/null)" ]; then
+            bridge_daemon_alive=1
+        fi
+    fi
+    if [ "$bridge_daemon_alive" = 0 ] && [ -f "$bridge_pane_file" ]; then
+        # Past the grace window with nothing holding the lock: the daemon is
+        # gone and the pane is a husk. Close it rather than leaving it for the
+        # user to find and close by hand.
+        dead_pane=$(cat "$bridge_pane_file") || dead_pane=
+        if [ -n "$dead_pane" ]; then
+            if helper_lantern_pane_workspace \
+                "$real_herdr" "$dead_pane" "$bridge_pane_title" >/dev/null 2>&1; then
+                "$real_herdr" pane close "$dead_pane" >/dev/null 2>&1 || true
+            fi
+        fi
+    fi
+
+    if [ "$bridge_daemon_alive" = 1 ] && [ -f "$bridge_pane_file" ]; then
         bridge_pane=$(cat "$bridge_pane_file") || bridge_pane=
         if [ -n "$bridge_pane" ]; then
             # The title check is what makes a remembered id safe: Herdr reuses

--- a/bridge.sh
+++ b/bridge.sh
@@ -93,7 +93,23 @@ if [ "${1:-}" = "--open" ]; then
     # cursor, two Slack pollers answer every message twice, and the second
     # webhook cannot bind its port. The daemon holds a lock of its own; this is
     # the cheap half, so a second press focuses instead of racing for it.
-    open_state_dir=${HERDR_PLUGIN_STATE_DIR:-${HERDR_PLUGIN_CONFIG_DIR:-$plugin_root}/state}
+    # Resolve this the way the daemon does, further down, or the probe reads
+    # a lock the daemon never takes. With no env vars, `${HERDR_PLUGIN_CONFIG_DIR:-$plugin_root}/state`
+    # is the checkout while the daemon locks under the plugin config directory,
+    # so the probe always answered "nothing running", closed the live pane past
+    # the grace window, and started a second bridge that died on the lock the
+    # first one held. Reading pane.id survived that only because it was written
+    # under the same wrong directory; a lock is not.
+    open_config_dir=${HERDR_PLUGIN_CONFIG_DIR:-}
+    if [ -z "$open_config_dir" ]; then
+        open_config_dir=$("$real_herdr" plugin config-dir aigora.lantern 2>/dev/null) ||
+            open_config_dir=
+    fi
+    if [ -n "$open_config_dir" ]; then
+        open_state_dir=${HERDR_PLUGIN_STATE_DIR:-$open_config_dir/state}
+    else
+        open_state_dir=${HERDR_PLUGIN_STATE_DIR:-$plugin_root/state}
+    fi
     bridge_pane_file=$open_state_dir/bridge/pane.id
 
     # A remembered pane is only worth focusing while a daemon is alive in it.
@@ -104,13 +120,28 @@ if [ "${1:-}" = "--open" ]; then
     #
     # The path itself stays set either way: the open below records the new
     # pane id in it.
+    # Exit 0 is "a daemon holds the lock", 1 is "none does". Anything else is
+    # the probe failing to answer, and the two wrong answers are not
+    # symmetrical: a false "running" leaves a dead pane focused, which is
+    # annoying, while a false "not running" closes a live pane and seats a
+    # second daemon, which breaks every channel. So only a clean 1 is allowed
+    # to close anything.
     bridge_daemon_alive=1
     open_python=$(helper_detect_python) || open_python=
     if [ -n "$open_python" ]; then
         # shellcheck disable=SC2086
         $open_python "$plugin_root/bin/lantern-bridge" \
-            --daemon-running --state "$open_state_dir" >/dev/null 2>&1 ||
-            bridge_daemon_alive=0
+            --daemon-running --state "$open_state_dir" >/dev/null 2>&1
+        open_probe_status=$?
+        case $open_probe_status in
+        0) bridge_daemon_alive=1 ;;
+        1) bridge_daemon_alive=0 ;;
+        *)
+            bridge_daemon_alive=1
+            printf 'lantern bridge: could not tell whether a bridge is already running (probe exit %s); leaving the pane alone\n' \
+                "$open_probe_status" >&2
+            ;;
+        esac
     fi
     if [ "$bridge_daemon_alive" = 0 ] && [ -f "$bridge_pane_file" ]; then
         # An unheld lock is not proof of death. Herdr has to start bridge.sh

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -805,13 +805,20 @@ class SlackParseTest(unittest.TestCase):
         # channel's poll down each cycle.
         self.adapter.dms["D77"] = "U1"
         self.adapter.cursors["D77"] = "1000.000000"
-        self.adapter._poll_order = ["D77"]
         lines = []
         original = lb.log
         lb.log = lines.append
         self.addCleanup(setattr, lb, "log", original)
         original_http = lb.http_json
-        lb.http_json = lambda *a, **k: {"ok": False, "error": "missing_scope"}
+
+        def per_conversation(url, payload=None, headers=None, timeout=None):
+            # The channel reads fine; only the DM is unreadable. That is the
+            # shape of im:write granted without im:history.
+            if "channel=D77" in url:
+                return {"ok": False, "error": "missing_scope"}
+            return {"ok": True, "messages": []}
+
+        lb.http_json = per_conversation
         self.addCleanup(setattr, lb, "http_json", original_http)
         original_sleep = lb.time.sleep
         lb.time.sleep = lambda _s: None
@@ -828,7 +835,9 @@ class SlackParseTest(unittest.TestCase):
         original_http = lb.http_json
         lb.http_json = lambda *a, **k: {"ok": False, "error": "ratelimited"}
         self.addCleanup(setattr, lb, "http_json", original_http)
-        self.adapter._poll_order = ["C123"]
+        original_sleep = lb.time.sleep
+        lb.time.sleep = lambda _s: None
+        self.addCleanup(setattr, lb.time, "sleep", original_sleep)
         with self.assertRaises(RuntimeError):
             self.adapter.poll_once()
 
@@ -870,10 +879,29 @@ class SlackParseTest(unittest.TestCase):
         self.assertEqual(url, "https://slack.com/api/conversations.open")
         self.assertEqual(payload, {"users": "U1"})
 
-    def test_poll_order_round_robins_the_channel_and_every_dm(self):
+    def test_a_small_watch_list_is_read_whole_every_pass(self):
+        # Round-robin made a DM wait len(watched) * SLACK_POLL seconds before
+        # anyone looked at it, for no benefit at this size.
         self.adapter.dms = {"D1": "U1", "D2": "U2"}
-        seen = [self.adapter.poll_conversations()[0] for _ in range(6)]
-        self.assertEqual(seen, ["C123", "D1", "D2", "C123", "D1", "D2"])
+        self.assertEqual(self.adapter.poll_conversations(), ["C123", "D1", "D2"])
+        self.assertEqual(self.adapter.poll_conversations(), ["C123", "D1", "D2"])
+
+    def test_the_interval_stretches_to_stay_inside_the_rate_limit(self):
+        # Rate is held by slowing the pass rather than reading fewer
+        # conversations, so each one still waits exactly one interval.
+        one = self.adapter.poll_interval(["C123"])
+        self.assertEqual(one, lb.SLACK_POLL)
+        many = ["C123"] + ["D%d" % i for i in range(20)]
+        stretched = self.adapter.poll_interval(many)
+        self.assertGreater(stretched, lb.SLACK_POLL)
+        requests_per_minute = len(many) * (60.0 / stretched)
+        self.assertLessEqual(requests_per_minute, lb.SLACK_TIER3_BUDGET + 0.001)
+
+    def test_every_watched_conversation_waits_one_interval(self):
+        watched = ["C123"] + ["D%d" % i for i in range(5)]
+        interval = self.adapter.poll_interval(watched)
+        # Round-robin would have been len(watched) * interval for each one.
+        self.assertLess(interval, len(watched) * lb.SLACK_POLL)
 
     def test_own_bot_message_is_skipped(self):
         accepted, oldest = self.parse(
@@ -1015,6 +1043,72 @@ class SlackSendTest(unittest.TestCase):
             self.assertLessEqual(len(payload["text"]), lb.SLACK_LIMIT)
             # Every chunk of a threaded reply stays in the thread.
             self.assertEqual(payload["thread_ts"], "1001.000100")
+
+
+class WhatsAppDedupeTest(unittest.TestCase):
+    """Meta documents delivery as at-least-once and retries anything it does
+    not see acknowledged. The bridge answers before the helper finishes, so a
+    redelivery would run the helper twice and reply twice."""
+
+    def setUp(self):
+        cfg = base_config(
+            WHATSAPP_ACCESS_TOKEN="access-token-value",
+            WHATSAPP_PHONE_NUMBER_ID="PN1",
+            WHATSAPP_VERIFY_TOKEN="verify-token-value",
+            WHATSAPP_APP_SECRET="app-secret-value",
+            WHATSAPP_ALLOWED_NUMBERS="15551234567",
+        )
+        self.adapter = lb.WhatsAppAdapter(cfg, queue.Queue())
+        original = lb.log
+        lb.log = lambda _m: None
+        self.addCleanup(setattr, lb, "log", original)
+
+    def body(self, message_id, text="light the field"):
+        return {
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "value": {
+                                "messages": [
+                                    {
+                                        "id": message_id,
+                                        "type": "text",
+                                        "from": "15551234567",
+                                        "text": {"body": text},
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def test_extraction_carries_the_message_id(self):
+        self.assertEqual(
+            self.adapter.extract_messages(self.body("wamid.1")),
+            [("wamid.1", "15551234567", "light the field")],
+        )
+
+    def test_the_same_message_is_answered_once(self):
+        self.assertEqual(len(self.adapter.accepted_from(self.body("wamid.1"))), 1)
+        self.assertEqual(self.adapter.accepted_from(self.body("wamid.1")), [])
+
+    def test_a_different_message_still_gets_through(self):
+        self.adapter.accepted_from(self.body("wamid.1"))
+        self.assertEqual(len(self.adapter.accepted_from(self.body("wamid.2"))), 1)
+
+    def test_a_body_with_no_id_is_not_dropped(self):
+        payload = self.body("wamid.3")
+        del payload["entry"][0]["changes"][0]["value"]["messages"][0]["id"]
+        self.assertEqual(len(self.adapter.accepted_from(payload)), 1)
+        self.assertEqual(len(self.adapter.accepted_from(payload)), 1)
+
+    def test_the_seen_set_stays_bounded(self):
+        for i in range(700):
+            self.adapter.remember("wamid.%d" % i)
+        self.assertLessEqual(len(self.adapter.seen), 512)
 
 
 WHATSAPP_SECRET = "app-secret-value"

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -831,6 +831,22 @@ class SlackParseTest(unittest.TestCase):
         self.assertTrue(any("missing_scope" in line for line in lines), lines)
         self.assertTrue(any("im:history" in line for line in lines), lines)
 
+    def test_the_rate_limit_holds_when_a_poll_fails(self):
+        # The sleep is the rate limit, not a courtesy. On the failure path it
+        # used to be skipped entirely, leaving Adapter.run's five second
+        # backoff to send len(watched) requests every five seconds.
+        slept = []
+        original_sleep = lb.time.sleep
+        lb.time.sleep = slept.append
+        self.addCleanup(setattr, lb.time, "sleep", original_sleep)
+        original_http = lb.http_json
+        lb.http_json = lambda *a, **k: (_ for _ in ()).throw(OSError("429"))
+        self.addCleanup(setattr, lb, "http_json", original_http)
+
+        with self.assertRaises(OSError):
+            self.adapter.poll_once()
+        self.assertEqual(slept, [self.adapter.poll_interval(["C123"])])
+
     def test_the_channel_failing_still_raises(self):
         original_http = lb.http_json
         lb.http_json = lambda *a, **k: {"ok": False, "error": "ratelimited"}
@@ -840,6 +856,55 @@ class SlackParseTest(unittest.TestCase):
         self.addCleanup(setattr, lb.time, "sleep", original_sleep)
         with self.assertRaises(RuntimeError):
             self.adapter.poll_once()
+
+    def test_a_transient_dm_error_keeps_the_dm(self):
+        # Every watched conversation is read on every pass now, so one bad
+        # window would otherwise retire every DM at once, and open_dms does not
+        # reopen one after its first success.
+        self.adapter.dms["D77"] = "U1"
+        self.adapter.cursors["D77"] = "1000.000000"
+        original = lb.log
+        lb.log = lambda _m: None
+        self.addCleanup(setattr, lb, "log", original)
+        original_sleep = lb.time.sleep
+        lb.time.sleep = lambda _s: None
+        self.addCleanup(setattr, lb.time, "sleep", original_sleep)
+        original_http = lb.http_json
+
+        def flaky(url, payload=None, headers=None, timeout=None):
+            if "channel=D77" in url:
+                return {"ok": False, "error": "ratelimited"}
+            return {"ok": True, "messages": []}
+
+        lb.http_json = flaky
+        self.addCleanup(setattr, lb, "http_json", original_http)
+
+        self.adapter.poll_once()
+        self.assertIn("D77", self.adapter.dms)
+
+    def test_a_permanent_dm_error_retires_the_dm(self):
+        self.adapter.dms["D77"] = "U1"
+        self.adapter.cursors["D77"] = "1000.000000"
+        lines = []
+        original = lb.log
+        lb.log = lines.append
+        self.addCleanup(setattr, lb, "log", original)
+        original_sleep = lb.time.sleep
+        lb.time.sleep = lambda _s: None
+        self.addCleanup(setattr, lb.time, "sleep", original_sleep)
+        original_http = lb.http_json
+
+        def scoped(url, payload=None, headers=None, timeout=None):
+            if "channel=D77" in url:
+                return {"ok": False, "error": "missing_scope"}
+            return {"ok": True, "messages": []}
+
+        lb.http_json = scoped
+        self.addCleanup(setattr, lb, "http_json", original_http)
+
+        self.adapter.poll_once()
+        self.assertNotIn("D77", self.adapter.dms)
+        self.assertTrue(any("missing_scope" in line for line in lines), lines)
 
     def test_dms_are_retried_after_a_blip_rather_than_given_up_on(self):
         # A network failure at daemon start must not turn DMs off for the life
@@ -1108,7 +1173,60 @@ class WhatsAppDedupeTest(unittest.TestCase):
     def test_the_seen_set_stays_bounded(self):
         for i in range(700):
             self.adapter.remember("wamid.%d" % i)
-        self.assertLessEqual(len(self.adapter.seen), 512)
+        self.assertLessEqual(len(self.adapter.seen), lb.WHATSAPP_SEEN_MAX)
+
+    def test_eviction_drops_the_oldest_not_the_alphabetically_first(self):
+        # A wamid carries no time order, so sorting the ids evicts arbitrary
+        # entries. One that arrived a second ago could be dropped, Meta would
+        # retry it, and the helper would run twice: the exact bug the seen
+        # record exists to prevent.
+        first = "wamid.zzz_oldest"
+        self.adapter.remember(first)
+        for i in range(lb.WHATSAPP_SEEN_MAX):
+            self.adapter.remember("wamid.aaa_%06d" % i)
+        newest = "wamid.aaa_%06d" % (lb.WHATSAPP_SEEN_MAX - 1)
+        self.assertNotIn(first, self.adapter.seen)
+        self.assertIn(newest, self.adapter.seen)
+
+    def test_two_threads_carrying_one_redelivery_only_one_wins(self):
+        # do_POST runs on ThreadingHTTPServer workers, so a check followed by
+        # a separate add lets both threads decide they are first.
+        import threading as _threading
+
+        winners = []
+        start = _threading.Barrier(8)
+
+        def race():
+            start.wait()
+            if not self.adapter.seen_before("wamid.race"):
+                winners.append(1)
+
+        threads = [_threading.Thread(target=race) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(len(winners), 1)
+
+    def test_recording_while_another_thread_evicts_does_not_raise(self):
+        import threading as _threading
+
+        errors = []
+
+        def churn(tag):
+            try:
+                for i in range(400):
+                    self.adapter.seen_before("wamid.%s_%d" % (tag, i))
+            except Exception as exc:  # noqa: BLE001 - the point of the test
+                errors.append(exc)
+
+        threads = [_threading.Thread(target=churn, args=(t,)) for t in "abcd"]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+        self.assertLessEqual(len(self.adapter.seen), lb.WHATSAPP_SEEN_MAX)
 
 
 WHATSAPP_SECRET = "app-secret-value"

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -882,6 +882,27 @@ class SlackParseTest(unittest.TestCase):
         self.adapter.poll_once()
         self.assertIn("D77", self.adapter.dms)
 
+    def test_the_last_retired_dm_can_come_back_without_a_restart(self):
+        # A scope error's remedy is reinstalling the Slack app. open_dms stops
+        # asking once it has opened one DM, so without a timer reset the
+        # reinstall would take effect only at the next daemon restart.
+        self.adapter.dms["D77"] = "U1"
+        self.adapter.cursors["D77"] = "1000.000000"
+        self.adapter._dms_next_try = float("inf")
+        original = lb.log
+        lb.log = lambda _m: None
+        self.addCleanup(setattr, lb, "log", original)
+
+        self.adapter.drop_conversation("D77")
+        self.assertEqual(self.adapter.dms, {})
+        self.assertNotEqual(self.adapter._dms_next_try, float("inf"))
+
+        original_http = lb.http_json
+        lb.http_json = lambda *a, **k: {"ok": True, "channel": {"id": "D88"}}
+        self.addCleanup(setattr, lb, "http_json", original_http)
+        self.adapter.open_dms(now=self.adapter._dms_next_try + 1.0)
+        self.assertIn("D88", self.adapter.dms)
+
     def test_a_permanent_dm_error_retires_the_dm(self):
         self.adapter.dms["D77"] = "U1"
         self.adapter.cursors["D77"] = "1000.000000"
@@ -1708,6 +1729,58 @@ class DaemonLockTest(unittest.TestCase):
         self.take()
         body = lb.daemon_lock_path(self.state).read_text(encoding="utf-8")
         self.assertEqual(body.strip(), str(os.getpid()))
+
+
+class DaemonProbeLockTest(unittest.TestCase):
+    """The probe and the daemon share one lock, moments apart."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.addCleanup(lb.release_daemon_locks)
+        self.state = tmp.name
+
+    def test_probe_then_immediate_acquire_succeeds(self):
+        # --open probes, then seats a pane whose daemon takes this same lock
+        # a moment later. Windows may not release a byte-range lock promptly
+        # on handle close, so the probe has to let go explicitly.
+        self.assertFalse(lb.daemon_running(self.state))
+        fd = lb.acquire_daemon_lock(self.state)
+        self.assertIsNotNone(fd)
+        os.close(fd)
+
+    def test_probe_sees_a_held_lock_and_releases_nothing(self):
+        fd = lb.acquire_daemon_lock(self.state)
+        try:
+            self.assertTrue(lb.daemon_running(self.state))
+            # The probe must not have broken the daemon's hold.
+            self.assertTrue(lb.daemon_running(self.state))
+        finally:
+            os.close(fd)
+        self.assertFalse(lb.daemon_running(self.state))
+
+    def test_acquire_retries_once_when_the_probe_holds_the_lock(self):
+        # A second --open press can hold the probe lock at the instant a
+        # starting daemon asks for it. One retry outlives that moment.
+        calls = []
+        original = lb._take_lock
+
+        def contended_once(fd):
+            calls.append(1)
+            if len(calls) == 1:
+                return False
+            return original(fd)
+
+        lb._take_lock = contended_once
+        self.addCleanup(setattr, lb, "_take_lock", original)
+        original_sleep = lb.time.sleep
+        lb.time.sleep = lambda _s: None
+        self.addCleanup(setattr, lb.time, "sleep", original_sleep)
+
+        fd = lb.acquire_daemon_lock(self.state)
+        self.assertIsNotNone(fd)
+        self.assertEqual(len(calls), 2)
+        os.close(fd)
 
 
 class DispatchLoopTest(unittest.TestCase):

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -29,8 +29,10 @@ open_dir=
 bridge_dir=
 autostart_dir=
 deadpane_dir=
+statedir_dir=
+probe_dir=
 elves_tmp=
-trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$fake_cmd" ] && rm -rf "$fake_cmd"; [ -n "$fake_py" ] && rm -rf "$fake_py"; [ -n "$fake_agents" ] && rm -rf "$fake_agents"; [ -n "$argv_dir" ] && rm -rf "$argv_dir"; [ -n "$open_dir" ] && rm -rf "$open_dir"; [ -n "$bridge_dir" ] && rm -rf "$bridge_dir"; [ -n "$autostart_dir" ] && rm -rf "$autostart_dir"; [ -n "$deadpane_dir" ] && rm -rf "$deadpane_dir"; [ -n "$elves_tmp" ] && rm -rf "$elves_tmp"' EXIT
+trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$fake_cmd" ] && rm -rf "$fake_cmd"; [ -n "$fake_py" ] && rm -rf "$fake_py"; [ -n "$fake_agents" ] && rm -rf "$fake_agents"; [ -n "$argv_dir" ] && rm -rf "$argv_dir"; [ -n "$open_dir" ] && rm -rf "$open_dir"; [ -n "$bridge_dir" ] && rm -rf "$bridge_dir"; [ -n "$autostart_dir" ] && rm -rf "$autostart_dir"; [ -n "$deadpane_dir" ] && rm -rf "$deadpane_dir"; [ -n "$statedir_dir" ] && rm -rf "$statedir_dir"; [ -n "$probe_dir" ] && rm -rf "$probe_dir"; [ -n "$elves_tmp" ] && rm -rf "$elves_tmp"' EXIT
 
 printf '%s\n' 'HELPER_AGENT="devin"' 'HELPER_SPAWN_KIND="claude"' >"$tmp"
 HELPER_AGENT=""
@@ -1418,5 +1420,106 @@ fi
 rm -rf "$deadpane_dir"
 deadpane_dir=
 printf 'ok: a dead bridge pane is replaced, not focused\n'
+
+# --open has to look for the lock where the daemon takes it. With no
+# HERDR_PLUGIN_STATE_DIR the daemon uses $config_dir/state, so an --open that
+# fell back to the checkout probed a lock nobody holds, always answered
+# "nothing running", closed the live pane past the grace window, and started a
+# second bridge that died on the first one's lock. Reading pane.id survived
+# that only because it was written under the same wrong directory.
+statedir_dir=$(mktemp -d)
+mkdir -p "$statedir_dir/config/state/bridge" "$statedir_dir/bin"
+cat >"$statedir_dir/bin/herdr" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$STATEDIR_LOG"
+case "$1 $2 $3" in
+"pane get"*)
+    printf '{"result":{"pane":{"label":"Lantern Bridge","pane_id":"w1:p2","workspace_id":"w1"}}}\n'
+    ;;
+"workspace get"*)
+    printf '{"result":{"workspace":{"label":"x","workspace_id":"w1"}}}\n'
+    ;;
+"plugin pane open"*)
+    printf '{"result":{"plugin_pane":{"pane":{"label":"Lantern Bridge","pane_id":"w1:p9","workspace_id":"w1"}}}}\n'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$statedir_dir/bin/herdr"
+# The pane id lives under the config directory, where the daemon would put it.
+# Nothing is written into the checkout.
+printf 'w1:p2\n' >"$statedir_dir/config/state/bridge/pane.id"
+touch -t 202001010000 "$statedir_dir/config/state/bridge/pane.id"
+STATEDIR_LOG=$statedir_dir/calls.txt
+export STATEDIR_LOG
+: >"$STATEDIR_LOG"
+
+HERDR_PLUGIN_ROOT="$root" \
+    HERDR_PLUGIN_CONFIG_DIR="$statedir_dir/config" \
+    HERDR_BIN_PATH="$statedir_dir/bin/herdr" \
+    sh "$root/bridge.sh" --open </dev/null >/dev/null 2>&1 ||
+    fail "open without HERDR_PLUGIN_STATE_DIR should still succeed"
+grep -q 'pane close w1:p2' "$STATEDIR_LOG" ||
+    fail "open should read the state directory under the config dir, not the checkout"
+if [ -e "$root/state" ]; then
+    fail "open must not create a state directory inside the checkout"
+fi
+rm -rf "$statedir_dir"
+statedir_dir=
+
+# A probe that cannot answer must not be read as "nothing running". The wrong
+# answers are not symmetrical: a false "running" leaves a dead pane focused, a
+# false "not running" closes a live pane and seats a second daemon.
+probe_dir=$(mktemp -d)
+mkdir -p "$probe_dir/state/bridge" "$probe_dir/bin" "$probe_dir/config" "$probe_dir/py"
+cat >"$probe_dir/bin/herdr" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$PROBE_LOG"
+case "$1 $2 $3" in
+"pane get"*)
+    printf '{"result":{"pane":{"label":"Lantern Bridge","pane_id":"w1:p2","workspace_id":"w1"}}}\n'
+    ;;
+"workspace get"*)
+    printf '{"result":{"workspace":{"label":"x","workspace_id":"w1"}}}\n'
+    ;;
+"plugin pane open"*)
+    printf '{"result":{"plugin_pane":{"pane":{"label":"Lantern Bridge","pane_id":"w1:p9","workspace_id":"w1"}}}}\n'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$probe_dir/bin/herdr"
+# Passes helper_detect_python's version check, then fails the probe with 2.
+cat >"$probe_dir/py/python3" <<'EOF'
+#!/bin/sh
+case "$*" in
+*version_info*) exit 0 ;;
+*--daemon-running*) exit 2 ;;
+esac
+exit 0
+EOF
+chmod +x "$probe_dir/py/python3"
+printf 'w1:p2\n' >"$probe_dir/state/bridge/pane.id"
+touch -t 202001010000 "$probe_dir/state/bridge/pane.id"
+PROBE_LOG=$probe_dir/calls.txt
+export PROBE_LOG
+: >"$PROBE_LOG"
+
+probe_err=$probe_dir/err.txt
+PATH="$probe_dir/py:$PATH" \
+    HERDR_PLUGIN_ROOT="$root" \
+    HERDR_PLUGIN_CONFIG_DIR="$probe_dir/config" \
+    HERDR_PLUGIN_STATE_DIR="$probe_dir/state" \
+    HERDR_BIN_PATH="$probe_dir/bin/herdr" \
+    sh "$root/bridge.sh" --open </dev/null >/dev/null 2>"$probe_err" ||
+    fail "open should survive a probe that cannot answer"
+if grep -q 'pane close' "$PROBE_LOG"; then
+    fail "a probe that cannot answer must not close a pane"
+fi
+grep -q 'could not tell whether a bridge is already running' "$probe_err" ||
+    fail "a probe that cannot answer should say so"
+rm -rf "$probe_dir"
+probe_dir=
+printf 'ok: --open finds the daemon lock, and never guesses\n'
 
 printf 'ok\n'

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -28,8 +28,9 @@ argv_dir=
 open_dir=
 bridge_dir=
 autostart_dir=
+deadpane_dir=
 elves_tmp=
-trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$fake_cmd" ] && rm -rf "$fake_cmd"; [ -n "$fake_py" ] && rm -rf "$fake_py"; [ -n "$fake_agents" ] && rm -rf "$fake_agents"; [ -n "$argv_dir" ] && rm -rf "$argv_dir"; [ -n "$open_dir" ] && rm -rf "$open_dir"; [ -n "$bridge_dir" ] && rm -rf "$bridge_dir"; [ -n "$autostart_dir" ] && rm -rf "$autostart_dir"; [ -n "$elves_tmp" ] && rm -rf "$elves_tmp"' EXIT
+trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$fake_cmd" ] && rm -rf "$fake_cmd"; [ -n "$fake_py" ] && rm -rf "$fake_py"; [ -n "$fake_agents" ] && rm -rf "$fake_agents"; [ -n "$argv_dir" ] && rm -rf "$argv_dir"; [ -n "$open_dir" ] && rm -rf "$open_dir"; [ -n "$bridge_dir" ] && rm -rf "$bridge_dir"; [ -n "$autostart_dir" ] && rm -rf "$autostart_dir"; [ -n "$deadpane_dir" ] && rm -rf "$deadpane_dir"; [ -n "$elves_tmp" ] && rm -rf "$elves_tmp"' EXIT
 
 printf '%s\n' 'HELPER_AGENT="devin"' 'HELPER_SPAWN_KIND="claude"' >"$tmp"
 HELPER_AGENT=""
@@ -1360,5 +1361,62 @@ grep -q -- '"--autostart"' "$root/herdr-plugin.toml" ||
 rm -rf "$autostart_dir"
 autostart_dir=
 printf 'ok: bridge.sh autostart gate\n'
+
+# A remembered bridge pane is only worth focusing while a daemon is alive in
+# it. The pane keeps its title after its daemon dies, so the title check alone
+# focused a dead window forever and started nothing, with no sign from outside
+# that anything was wrong. The lock is the one thing only a live daemon holds,
+# and a startup grace window keeps a second press during startup from seating
+# a duplicate.
+deadpane_dir=$(mktemp -d)
+mkdir -p "$deadpane_dir/state/bridge" "$deadpane_dir/bin" "$deadpane_dir/config"
+cat >"$deadpane_dir/bin/herdr" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$DEADPANE_LOG"
+case "$1 $2 $3" in
+"pane get"*)
+    printf '{"result":{"pane":{"label":"Lantern Bridge","pane_id":"w1:p2","workspace_id":"w1"}}}\n'
+    ;;
+"workspace get"*)
+    printf '{"result":{"workspace":{"label":"x","workspace_id":"w1"}}}\n'
+    ;;
+"plugin pane open"*)
+    printf '{"result":{"plugin_pane":{"pane":{"label":"Lantern Bridge","pane_id":"w1:p9","workspace_id":"w1"}}}}\n'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$deadpane_dir/bin/herdr"
+printf 'w1:p2\n' >"$deadpane_dir/state/bridge/pane.id"
+# Older than the startup grace window, so this is a dead pane rather than one
+# still coming up.
+touch -t 202001010000 "$deadpane_dir/state/bridge/pane.id"
+DEADPANE_LOG=$deadpane_dir/calls.txt
+export DEADPANE_LOG
+: >"$DEADPANE_LOG"
+
+HERDR_PLUGIN_ROOT="$root" \
+    HERDR_PLUGIN_CONFIG_DIR="$deadpane_dir/config" \
+    HERDR_PLUGIN_STATE_DIR="$deadpane_dir/state" \
+    HERDR_BIN_PATH="$deadpane_dir/bin/herdr" \
+    sh "$root/bridge.sh" --open </dev/null >/dev/null 2>&1 ||
+    fail "open with a dead bridge pane should still succeed"
+grep -q 'plugin pane open' "$DEADPANE_LOG" ||
+    fail "open should seat a fresh pane when no daemon holds the lock"
+if grep -q 'plugin pane focus' "$DEADPANE_LOG"; then
+    fail "open must not focus a pane whose daemon is gone"
+fi
+grep -q 'pane close w1:p2' "$DEADPANE_LOG" ||
+    fail "open should close the husk rather than leave it for the user"
+
+# The probe itself: nothing holds this lock.
+# shellcheck disable=SC2086
+if $smoke_python "$root/bin/lantern-bridge" --daemon-running \
+    --state "$deadpane_dir/state" >/dev/null 2>&1; then
+    fail "--daemon-running should report nothing running here"
+fi
+rm -rf "$deadpane_dir"
+deadpane_dir=
+printf 'ok: a dead bridge pane is replaced, not focused\n'
 
 printf 'ok\n'


### PR DESCRIPTION
First batch of the pre-handoff bug work. Closes #10.

**A dead bridge pane was focused forever.** The action and autostart matched the remembered pane on its title, which a pane keeps after its daemon dies, so every attempt to start the bridge focused a dead window and started nothing, silently. `lantern-bridge --daemon-running` now asks the advisory lock, which only a live daemon holds. A two minute grace window from when the pane id was recorded keeps a second press during startup from seating a duplicate, and past that window the husk is closed rather than left behind.

**WhatsApp answered redeliveries twice (#10).** Meta documents delivery as at-least-once and the bridge answers before the helper finishes, so a retry ran the helper again and sent a second reply. There is now a bounded seen-id set, matching what Telegram and Slack already had. A message with no id is still answered rather than dropped.

**Slack DMs waited N intervals.** Polling read one conversation per pass, so each DM waited len(watched) intervals before anyone looked at it. That was mine, added with DM support, and the wrong lever: the rate limit is held by stretching the interval instead, so every conversation waits exactly one interval for the same requests per minute. One conversation is unchanged at 3s.

153 bridge unit tests and the full smoke suite pass, with new cases for each fix, including a reproduction of the dead-pane failure.