### PR TITLE
Slack: answer a channel only when mentioned, and write each channel's dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- The bridge answers a Slack channel only when the message mentions it. A
+  channel has other people in it, and answering everything an allowlisted
+  person says there is noise; a DM is still the whole conversation and needs
+  no mention. The bot's own user id comes from `auth.test`, which needs no
+  extra scope. Until that answers, the channel behaves as it did before and
+  the log says why, because a bot that has gone silent is harder to diagnose
+  than one that is too eager.
+- The helper is told each channel's formatting dialect. Ordinary Markdown is
+  wrong on all three and differently so: Slack reads `*one asterisk*`,
+  Telegram is sent with no parse mode at all, and WhatsApp uses single
+  markers. An agent writing `**bold**` was putting literal asterisks in front
+  of the reader.
+
 ## [0.6.0] - 2026-08-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to Lantern, by Elves are documented here.
   extra scope. Until that answers, the channel behaves as it did before and
   the log says why, because a bot that has gone silent is harder to diagnose
   than one that is too eager.
+- Conversation workdirs are re-seeded when the appendix changes. The helper's
+  instruction files were written once and never again, so a rule corrected in
+  a later build reached only conversations created after it: the formatting
+  note below would have gone nowhere near the conversations already getting
+  formatting wrong. The files now carry a version marker, and a file whose
+  marker is missing or older is rewritten. An edit that keeps the marker is
+  kept, and prompt.md in the config directory is never touched.
 - The helper is told each channel's formatting dialect. Ordinary Markdown is
   wrong on all three and differently so: Slack reads `*one asterisk*`,
   Telegram is sent with no parse mode at all, and WhatsApp uses single

--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ your member id (`U…`). The bridge polls that one channel and each allowlisted
 member's DM with the bot, and ignores everything it did not hear from an
 allowlisted human.
 
+In a channel it answers only when you `@Lantern` it. A DM is the whole
+conversation and needs no mention. That is the usual shape for a bot in a
+room with other people in it, and it is what keeps a shared channel usable.
+
 Replies follow the message and the session follows the person. A message in
 the channel is answered in its own thread, so the channel stays readable; a
 DM is answered in the DM. Both places share one conversation per person, so a

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -99,6 +99,9 @@ SLACK_POLL = 3.0
 # Slack rates conversations.history at Tier 3, about 50 requests a minute. Kept
 # under that so every watched conversation can be read on every pass.
 SLACK_TIER3_BUDGET = 45.0
+# How long to wait before asking Slack again who this token belongs to, when
+# the last attempt could not say.
+BOT_ID_RETRY = 60.0
 # Slack errors that will not fix themselves, so a DM returning one is retired
 # rather than retried. Everything else, rate limits included, is transient.
 SLACK_PERMANENT_ERRORS = frozenset(
@@ -482,6 +485,31 @@ def workdir_for(state_dir, channel: str, chat_id) -> Path:
     return conversation_dir(state_dir, channel, chat_id) / "workdir"
 
 
+# What survives on the way out, per channel. Ordinary Markdown is wrong on all
+# three: Slack has its own dialect, Telegram is sent without a parse mode on
+# purpose, and WhatsApp uses single markers. An agent writing **bold** puts
+# literal asterisks in front of the user.
+FORMATTING_NOTE = {
+    "slack": (
+        "Slack does not read ordinary Markdown. Bold is *one asterisk*, "
+        "italic is _underscores_, code is `backticks`. Never **two "
+        "asterisks**: they arrive as asterisks."
+    ),
+    "telegram": (
+        "This message is sent as plain text with no parse mode, so no "
+        "Markdown is rendered at all. Asterisks and underscores arrive "
+        "exactly as typed. Use plain words and line breaks."
+    ),
+    "whatsapp": (
+        "WhatsApp uses single markers: *bold*, _italic_, ```monospace```. "
+        "Never **two asterisks**: they arrive as asterisks."
+    ),
+    "default": (
+        "Write plain text. Do not assume any Markdown is rendered."
+    ),
+}
+
+
 def remote_appendix(cfg: dict, channel: str, search_root: str) -> str:
     """What the lantern prompt does not know: there is no pane and no terminal."""
     return """
@@ -505,6 +533,7 @@ Runtime (injected by the Lantern Bridge; do not ignore):
   see.
 - No tables and no headings; both read badly on a phone. Code fences only for
   code or a command.
+- %s
 - Prefer $HERDR_BIN_PATH when calling Herdr. A wrapper is first on PATH.
   Inspect commands (list/read/get) run as usual. Mutating commands (create,
   start, focus, close, remove, prompt, send-*) are blocked until the user
@@ -525,6 +554,7 @@ Runtime (injected by the Lantern Bridge; do not ignore):
   tab, or a pane unless the user names it.
 """ % (
         channel,
+        FORMATTING_NOTE.get(channel, FORMATTING_NOTE["default"]),
         cfg["BRIDGE_SPAWN_KIND"],
         search_root,
     )
@@ -820,6 +850,13 @@ class SlackAdapter(Adapter):
         self.seen = set()
         # DM conversation id -> allowlisted user id. Filled by open_dms.
         self.dms = {}
+        # The bot's own user id, so a channel message can be tested for a
+        # mention. Resolved lazily from auth.test, which needs no scope beyond
+        # a valid token. Until it is known the channel answers everything, the
+        # behaviour before mentions existed: a channel that has gone quiet is
+        # worse than a channel that is too eager, and the log says which.
+        self.bot_user_id = ""
+        self._bot_id_next_try = 0.0
         # Not a boolean: a network blip at daemon start (a laptop resuming, or
         # Herdr autostarting before DHCP) would otherwise turn DMs off for the
         # life of the process and report it as a missing scope.
@@ -839,6 +876,40 @@ class SlackAdapter(Adapter):
             }
         )
         return "https://slack.com/api/conversations.history?%s" % query
+
+    def resolve_bot_user_id(self, now=None) -> None:
+        """Ask Slack who this token is. Retried on a slow timer until known."""
+        now = time.time() if now is None else now
+        if self.bot_user_id or now < self._bot_id_next_try:
+            return
+        self._bot_id_next_try = now + BOT_ID_RETRY
+        try:
+            answer = http_json("https://slack.com/api/auth.test", headers=self.headers())
+        except Exception as exc:  # noqa: BLE001 - the channel still works
+            log("slack: could not learn my own user id (%s); answering every "
+                "allowlisted message in the channel until I can"
+                % exc.__class__.__name__)
+            return
+        if not answer.get("ok", False):
+            log("slack: could not learn my own user id (%s); answering every "
+                "allowlisted message in the channel until I can"
+                % answer.get("error", "unknown"))
+            return
+        user_id = answer.get("user_id")
+        if isinstance(user_id, str) and user_id:
+            self.bot_user_id = user_id
+            self._bot_id_next_try = float("inf")
+            log("slack: answering channel messages that mention me")
+
+    def mention_of_me(self) -> str:
+        return "<@%s>" % self.bot_user_id if self.bot_user_id else ""
+
+    def strip_mention(self, text: str) -> str:
+        """Take my own mention out, so the helper reads a plain request."""
+        mention = self.mention_of_me()
+        if not mention:
+            return text
+        return " ".join(text.replace(mention, " ").split())
 
     def dm_open_payload(self, user: str):
         return ("https://slack.com/api/conversations.open", {"users": user})
@@ -936,11 +1007,24 @@ class SlackAdapter(Adapter):
             text = message.get("text")
             if not isinstance(text, str) or not text.strip():
                 continue
+            body = text.strip()
             if conversation == self.channel:
+                # A channel has other people in it, and answering everything
+                # an allowlisted person says there is noise. A DM is the whole
+                # conversation; the channel is for being called on.
+                mention = self.mention_of_me()
+                if mention:
+                    if mention not in body:
+                        continue
+                    body = self.strip_mention(body)
+                    if not body:
+                        # Nothing but the mention. Worth answering, since the
+                        # person plainly wants attention.
+                        body = "hello"
                 reply_to = (conversation, ts, user)
             else:
                 reply_to = (conversation, None, user)
-            accepted.append((user, reply_to, text.strip()))
+            accepted.append((user, reply_to, body))
         return accepted, oldest
 
     def poll_conversations(self):
@@ -974,6 +1058,7 @@ class SlackAdapter(Adapter):
             self._dms_next_try = time.time() + DM_OPEN_RETRY
 
     def poll_once(self) -> None:
+        self.resolve_bot_user_id()
         self.open_dms()
         watched = self.poll_conversations()
         # The sleep is in a finally because it is the rate limit, not a

--- a/bin/lantern-bridge
+++ b/bin/lantern-bridge
@@ -86,6 +86,9 @@ SLACK_LIMIT = 4000
 # How many WhatsApp message ids to remember. Meta retries within minutes,
 # so this only has to outlast a retry window.
 WHATSAPP_SEEN_MAX = 512
+# Bump when the remote appendix changes in a way existing conversations need.
+# seed_workdir rewrites their instruction files when the marker does not match.
+APPENDIX_VERSION = 2
 WHATSAPP_LIMIT = 4096
 
 # A headless turn can legitimately run for minutes; it is still bounded.
@@ -510,6 +513,17 @@ FORMATTING_NOTE = {
 }
 
 
+# A mention of anyone, at the very start of a message. Used only while this
+# bridge does not yet know its own id.
+ANY_LEADING_MENTION_RE = re.compile(r"^[ \t]*<@[UW][A-Z0-9]+(?:\|[^>]*)?>[ \t]*")
+
+
+def _strip_around(pattern, text: str) -> str:
+    """Drop every match plus the spaces and tabs touching it. Keep newlines."""
+    spaced = re.compile(r"[ \t]*(?:%s)[ \t]*" % pattern.pattern)
+    return spaced.sub(" ", text).strip()
+
+
 def remote_appendix(cfg: dict, channel: str, search_root: str) -> str:
     """What the lantern prompt does not know: there is no pane and no terminal."""
     return """
@@ -560,22 +574,42 @@ Runtime (injected by the Lantern Bridge; do not ignore):
     )
 
 
-def seed_workdir(workdir: Path, prompt_text: str, appendix: str) -> bool:
-    """Write the helper's instruction files once, and only once.
+def appendix_marker(version=None) -> str:
+    version = APPENDIX_VERSION if version is None else version
+    return "<!-- lantern-bridge appendix v%d -->" % version
 
-    Once is the point: the helper edits nothing here, but a rewrite on every
-    turn would churn the mtimes a resumed session watches, and it would undo a
-    user who tuned the file by hand.
+
+def seed_workdir(workdir: Path, prompt_text: str, appendix: str) -> bool:
+    """Write the helper's instruction files, and replace an outdated set.
+
+    Not once and never again. A conversation keeps its workdir between turns,
+    so a rule corrected in a later build would never have reached any
+    conversation that already existed: the per-channel formatting note, for
+    one, would have gone only to conversations created after it shipped, while
+    the ones already getting the formatting wrong kept the old text forever.
+
+    A version marker in the file is what makes that decidable. Same version,
+    leave it alone, so ordinary turns do not churn the mtimes a resumed
+    session watches. Different or absent, write the current text. These files
+    are generated rather than owned by the user; the file people tune by hand
+    is prompt.md in the config directory, and that is never touched here.
     """
     workdir = Path(workdir)
     workdir.mkdir(parents=True, exist_ok=True)
-    full = prompt_text.rstrip("\n") + appendix
+    marker = appendix_marker()
+    full = prompt_text.rstrip("\n") + appendix + "\n" + marker + "\n"
     seeded = False
     for name in ("AGENTS.md", "CLAUDE.md"):
         target = workdir / name
-        if not target.exists():
-            target.write_text(full, encoding="utf-8")
-            seeded = True
+        if target.exists():
+            try:
+                if marker in target.read_text(encoding="utf-8"):
+                    continue
+            except OSError:
+                # Unreadable is as good a reason to rewrite as outdated.
+                pass
+        target.write_text(full, encoding="utf-8")
+        seeded = True
     return seeded
 
 
@@ -857,6 +891,7 @@ class SlackAdapter(Adapter):
         # worse than a channel that is too eager, and the log says which.
         self.bot_user_id = ""
         self._bot_id_next_try = 0.0
+        self._bot_id_complained = False
         # Not a boolean: a network blip at daemon start (a laptop resuming, or
         # Herdr autostarting before DHCP) would otherwise turn DMs off for the
         # life of the process and report it as a missing scope.
@@ -886,14 +921,10 @@ class SlackAdapter(Adapter):
         try:
             answer = http_json("https://slack.com/api/auth.test", headers=self.headers())
         except Exception as exc:  # noqa: BLE001 - the channel still works
-            log("slack: could not learn my own user id (%s); answering every "
-                "allowlisted message in the channel until I can"
-                % exc.__class__.__name__)
+            self._complain_about_bot_id(exc.__class__.__name__)
             return
         if not answer.get("ok", False):
-            log("slack: could not learn my own user id (%s); answering every "
-                "allowlisted message in the channel until I can"
-                % answer.get("error", "unknown"))
+            self._complain_about_bot_id(answer.get("error", "unknown"))
             return
         user_id = answer.get("user_id")
         if isinstance(user_id, str) and user_id:
@@ -901,15 +932,51 @@ class SlackAdapter(Adapter):
             self._bot_id_next_try = float("inf")
             log("slack: answering channel messages that mention me")
 
-    def mention_of_me(self) -> str:
-        return "<@%s>" % self.bot_user_id if self.bot_user_id else ""
+    def _complain_about_bot_id(self, reason: str) -> None:
+        """Say it once. Retried every minute, this would fill the pane."""
+        if self._bot_id_complained:
+            return
+        self._bot_id_complained = True
+        log(
+            "slack: could not learn my own user id (%s); answering every "
+            "allowlisted message in the channel until I can" % reason
+        )
+
+    def mention_pattern(self):
+        """My own mention, in both forms Slack emits, or None if unknown.
+
+        Slack writes a mention as <@U123>, and sometimes as <@U123|name>: the
+        labelled form turns up in older messages and in anything composed
+        through the API. Matching only the bare form left the bot silent on a
+        message that plainly called it, which is the failure this whole rule
+        is supposed to avoid.
+        """
+        if not self.bot_user_id:
+            return None
+        return re.compile(r"<@%s(?:\|[^>]*)?>" % re.escape(self.bot_user_id))
+
+    def mentions_me(self, text: str) -> bool:
+        pattern = self.mention_pattern()
+        return bool(pattern and pattern.search(text))
 
     def strip_mention(self, text: str) -> str:
-        """Take my own mention out, so the helper reads a plain request."""
-        mention = self.mention_of_me()
-        if not mention:
-            return text
-        return " ".join(text.replace(mention, " ").split())
+        """Take my own mention out, and change nothing else.
+
+        Only the mention and the spaces touching it go. An earlier version
+        rebuilt the message with " ".join(text.split()), which flattened every
+        line break and indent in it: a request carrying a code fence arrived
+        as one line with the fence markers stranded mid-sentence. The appendix
+        this bridge ships promises the helper that line breaks survive, and
+        mangling the question on the way in breaks that promise at the first
+        step.
+        """
+        pattern = self.mention_pattern()
+        if pattern is None:
+            # Before auth.test answers there is no id to match, so take a
+            # leading mention of anybody rather than hand the helper raw
+            # markup. Behaviour then matches the steady state.
+            return ANY_LEADING_MENTION_RE.sub("", text, count=1).strip()
+        return _strip_around(pattern, text)
 
     def dm_open_payload(self, user: str):
         return ("https://slack.com/api/conversations.open", {"users": user})
@@ -1012,15 +1079,14 @@ class SlackAdapter(Adapter):
                 # A channel has other people in it, and answering everything
                 # an allowlisted person says there is noise. A DM is the whole
                 # conversation; the channel is for being called on.
-                mention = self.mention_of_me()
-                if mention:
-                    if mention not in body:
+                if self.bot_user_id:
+                    if not self.mentions_me(body):
                         continue
-                    body = self.strip_mention(body)
-                    if not body:
-                        # Nothing but the mention. Worth answering, since the
-                        # person plainly wants attention.
-                        body = "hello"
+                body = self.strip_mention(body)
+                if not body:
+                    # Nothing but the mention. Worth answering, since the
+                    # person plainly wants attention.
+                    body = "hello"
                 reply_to = (conversation, ts, user)
             else:
                 reply_to = (conversation, None, user)

--- a/docs/slack-trial.md
+++ b/docs/slack-trial.md
@@ -176,8 +176,11 @@ action focuses a running bridge instead of seating another.
 moment the daemon comes up, so nothing in the channel's history is read. Start
 the daemon, then send your test message.
 
-**In a channel it answers only when you mention it.** Type `@Lantern` and it
-replies; say anything else in that channel and it stays quiet. In its DM you
+**In a channel it answers only when you mention it.** Type `@Lantern` at the
+channel's top level and it replies; say anything else in that channel and it
+stays quiet. A mention inside one of its own reply threads reaches nobody, for
+the same reason the thread footer gives: Slack's history API does not return
+thread replies, so the bridge cannot see them. In its DM you
 need no mention, because the DM is the conversation. If the bridge cannot work
 out its own user id, it says so in the log and answers every allowlisted
 message in the channel until it can, on the grounds that a silent bot is

--- a/docs/slack-trial.md
+++ b/docs/slack-trial.md
@@ -176,6 +176,13 @@ action focuses a running bridge instead of seating another.
 moment the daemon comes up, so nothing in the channel's history is read. Start
 the daemon, then send your test message.
 
+**In a channel it answers only when you mention it.** Type `@Lantern` and it
+replies; say anything else in that channel and it stays quiet. In its DM you
+need no mention, because the DM is the conversation. If the bridge cannot work
+out its own user id, it says so in the log and answers every allowlisted
+message in the channel until it can, on the grounds that a silent bot is
+harder to diagnose than a chatty one.
+
 **It answers you and ignores everyone else.** Messages from anyone outside
 `SLACK_ALLOWED_USERS` are dropped, as are the bot's own messages and Slack's
 join/leave notices.

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -779,6 +779,69 @@ class SlackParseTest(unittest.TestCase):
         self.assertEqual(accepted, [("U1", ("C123", "1001.000100", "U1"), "hi")])
         self.assertEqual(oldest, "1001.000100")
 
+    def test_the_channel_answers_only_a_mention(self):
+        # A channel has other people in it. Answering everything an
+        # allowlisted person says there is what made the trial noisy.
+        self.adapter.bot_user_id = "UBOT"
+        self.assertEqual(self.parse([slack_message("1001.000100", "U1", "chatting")])[0], [])
+        accepted, _ = self.parse(
+            [slack_message("1002.000100", "U1", "<@UBOT> what is running?")]
+        )
+        self.assertEqual(len(accepted), 1)
+
+    def test_the_mention_is_taken_out_of_the_text(self):
+        self.adapter.bot_user_id = "UBOT"
+        accepted, _ = self.parse(
+            [slack_message("1001.000100", "U1", "<@UBOT> what is running?")]
+        )
+        self.assertEqual(accepted[0][2], "what is running?")
+
+    def test_a_bare_mention_still_gets_an_answer(self):
+        self.adapter.bot_user_id = "UBOT"
+        accepted, _ = self.parse([slack_message("1001.000100", "U1", "<@UBOT>")])
+        self.assertEqual(accepted[0][2], "hello")
+
+    def test_a_dm_needs_no_mention(self):
+        self.adapter.bot_user_id = "UBOT"
+        self.adapter.dms["D77"] = "U1"
+        self.adapter.cursors["D77"] = "1000.000000"
+        accepted, _ = self.parse(
+            [slack_message("1001.000100", "U1", "no mention here")], conversation="D77"
+        )
+        self.assertEqual(len(accepted), 1)
+
+    def test_the_channel_answers_everything_until_the_bot_id_is_known(self):
+        # A quiet channel is worse than an eager one, and the log says which.
+        self.assertEqual(self.adapter.bot_user_id, "")
+        accepted, _ = self.parse([slack_message("1001.000100", "U1", "chatting")])
+        self.assertEqual(len(accepted), 1)
+
+    def test_the_bot_id_is_asked_for_again_after_a_failure(self):
+        calls = []
+        original = lb.http_json
+
+        def flaky(url, payload=None, headers=None, timeout=None):
+            calls.append(url)
+            if len(calls) == 1:
+                return {"ok": False, "error": "ratelimited"}
+            return {"ok": True, "user_id": "UBOT"}
+
+        lb.http_json = flaky
+        self.addCleanup(setattr, lb, "http_json", original)
+        original_log = lb.log
+        lb.log = lambda _m: None
+        self.addCleanup(setattr, lb, "log", original_log)
+
+        self.adapter.resolve_bot_user_id(now=0.0)
+        self.assertEqual(self.adapter.bot_user_id, "")
+        self.adapter.resolve_bot_user_id(now=1.0)
+        self.assertEqual(len(calls), 1)
+        self.adapter.resolve_bot_user_id(now=lb.BOT_ID_RETRY + 1.0)
+        self.assertEqual(self.adapter.bot_user_id, "UBOT")
+        # Known now, so it stops asking.
+        self.adapter.resolve_bot_user_id(now=lb.BOT_ID_RETRY * 100)
+        self.assertEqual(len(calls), 2)
+
     def test_a_dm_replies_in_the_dm_with_no_thread(self):
         self.adapter.dms["D77"] = "U1"
         self.adapter.cursors["D77"] = "1000.000000"
@@ -1063,6 +1126,30 @@ class SlackParseTest(unittest.TestCase):
             self.adapter.parse_history({"messages": [None, {"ts": "nope"}]}),
             ([], startup),
         )
+
+
+class FormattingNoteTest(unittest.TestCase):
+    """Ordinary Markdown is wrong on all three channels, differently."""
+
+    def note(self, channel):
+        cfg = base_config(BRIDGE_SPAWN_KIND="claude")
+        return lb.remote_appendix(cfg, channel, "/home/x")
+
+    def test_slack_is_told_its_own_dialect(self):
+        self.assertIn("*one asterisk*", self.note("slack"))
+
+    def test_telegram_is_told_nothing_renders(self):
+        self.assertIn("no parse mode", self.note("telegram"))
+
+    def test_whatsapp_is_told_single_markers(self):
+        self.assertIn("single markers", self.note("whatsapp"))
+
+    def test_every_channel_warns_off_double_asterisks(self):
+        for channel in ("slack", "whatsapp"):
+            self.assertIn("**two", self.note(channel))
+
+    def test_an_unknown_channel_still_gets_a_note(self):
+        self.assertIn("Do not assume any Markdown", self.note("carrier-pigeon"))
 
 
 class SlackSendTest(unittest.TestCase):

--- a/tests/bridge_test.py
+++ b/tests/bridge_test.py
@@ -471,9 +471,27 @@ class WorkdirTest(unittest.TestCase):
             self.assertIn("HERDR_HELPER_OK=1", body)
             self.assertIn("telegram", body)
             self.assertIn("/home/j", body)
-        (wd / "AGENTS.md").write_text("EDITED", encoding="utf-8")
+        # An edit that keeps the version marker is kept. The marker is a line
+        # in the file, so this is visible to whoever is editing it.
+        kept = "EDITED\n" + lb.appendix_marker() + "\n"
+        (wd / "AGENTS.md").write_text(kept, encoding="utf-8")
         self.assertFalse(lb.seed_workdir(wd, "PROMPT BODY", appendix))
-        self.assertEqual((wd / "AGENTS.md").read_text(encoding="utf-8"), "EDITED")
+        self.assertEqual((wd / "AGENTS.md").read_text(encoding="utf-8"), kept)
+
+    def test_an_edit_that_drops_the_marker_is_replaced(self):
+        # These files are generated. Preserving an unmarked edit forever was
+        # what kept corrected rules from ever reaching a conversation that
+        # already existed. The file people tune by hand is prompt.md in the
+        # config directory, and seeding never touches it.
+        wd = lb.workdir_for(self.state, "telegram", 8)
+        cfg = base_config(BRIDGE_HELPER="claude")
+        appendix = lb.remote_appendix(cfg, "telegram", "/home/j")
+        lb.seed_workdir(wd, "PROMPT BODY", appendix)
+        (wd / "AGENTS.md").write_text("EDITED, no marker", encoding="utf-8")
+        self.assertTrue(lb.seed_workdir(wd, "PROMPT BODY", appendix))
+        body = (wd / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertIn("PROMPT BODY", body)
+        self.assertNotIn("EDITED", body)
 
     def test_session_marker_drives_resume(self):
         wd = lb.workdir_for(self.state, "slack", "C1")
@@ -795,6 +813,55 @@ class SlackParseTest(unittest.TestCase):
             [slack_message("1001.000100", "U1", "<@UBOT> what is running?")]
         )
         self.assertEqual(accepted[0][2], "what is running?")
+
+    def test_stripping_the_mention_keeps_the_shape_of_the_message(self):
+        # An earlier version rebuilt the text with " ".join(text.split()),
+        # which flattened every line break and indent: a code fence arrived as
+        # one line with its markers stranded mid-sentence. The appendix this
+        # bridge ships promises the helper that line breaks survive.
+        self.adapter.bot_user_id = "UBOT"
+        body = "<@UBOT> run this:\n```\nline1\n  line2\n```"
+        stripped = self.adapter.strip_mention(body)
+        self.assertEqual(stripped, "run this:\n```\nline1\n  line2\n```")
+        self.assertEqual(stripped.count("\n"), body.count("\n"))
+        self.assertIn("\n  line2", stripped)
+
+    def test_the_labelled_mention_form_counts(self):
+        # Slack writes <@U123|name> in older messages and anything composed
+        # through the API. Missing it left the bot silent on a message that
+        # plainly called it.
+        self.adapter.bot_user_id = "UBOT"
+        self.assertTrue(self.adapter.mentions_me("<@UBOT|lantern> hi"))
+        self.assertEqual(self.adapter.strip_mention("<@UBOT|lantern> hi"), "hi")
+
+    def test_somebody_elses_mention_is_not_mine(self):
+        self.adapter.bot_user_id = "UBOT"
+        for other in ("<@UOTHER> hi", "<!here> hi", "<!subteam^S1|@team> hi"):
+            self.assertFalse(self.adapter.mentions_me(other), other)
+
+    def test_the_fail_open_window_still_hands_over_clean_text(self):
+        # No id yet, so every message is answered; the helper should still not
+        # be handed raw mention markup.
+        self.assertEqual(self.adapter.bot_user_id, "")
+        accepted, _ = self.parse(
+            [slack_message("1001.000100", "U1", "<@UBOT> what is running?")]
+        )
+        self.assertEqual(accepted[0][2], "what is running?")
+        accepted, _ = self.parse([slack_message("1002.000100", "U1", "<@UBOT>")])
+        self.assertEqual(accepted[0][2], "hello")
+
+    def test_the_missing_bot_id_is_reported_once_not_every_minute(self):
+        lines = []
+        original_log = lb.log
+        lb.log = lines.append
+        self.addCleanup(setattr, lb, "log", original_log)
+        original_http = lb.http_json
+        lb.http_json = lambda *a, **k: {"ok": False, "error": "ratelimited"}
+        self.addCleanup(setattr, lb, "http_json", original_http)
+
+        for minute in range(5):
+            self.adapter.resolve_bot_user_id(now=minute * (lb.BOT_ID_RETRY + 1.0))
+        self.assertEqual(len([l for l in lines if "my own user id" in l]), 1)
 
     def test_a_bare_mention_still_gets_an_answer(self):
         self.adapter.bot_user_id = "UBOT"
@@ -1125,6 +1192,49 @@ class SlackParseTest(unittest.TestCase):
         self.assertEqual(
             self.adapter.parse_history({"messages": [None, {"ts": "nope"}]}),
             ([], startup),
+        )
+
+
+class SeedWorkdirTest(unittest.TestCase):
+    """A conversation keeps its workdir, so a corrected rule has to reach the
+    conversations that already exist."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.workdir = Path(tmp.name) / "workdir"
+
+    def test_a_new_workdir_is_seeded(self):
+        self.assertTrue(lb.seed_workdir(self.workdir, "PROMPT", "\n- a rule\n"))
+        for name in ("AGENTS.md", "CLAUDE.md"):
+            text = (self.workdir / name).read_text(encoding="utf-8")
+            self.assertIn("- a rule", text)
+            self.assertIn(lb.appendix_marker(), text)
+
+    def test_an_unmarked_workdir_from_an_older_build_is_rewritten(self):
+        self.workdir.mkdir(parents=True)
+        for name in ("AGENTS.md", "CLAUDE.md"):
+            (self.workdir / name).write_text("PROMPT\n\nold text\n", encoding="utf-8")
+        self.assertTrue(lb.seed_workdir(self.workdir, "PROMPT", "\n- a new rule\n"))
+        text = (self.workdir / "CLAUDE.md").read_text(encoding="utf-8")
+        self.assertIn("- a new rule", text)
+        self.assertNotIn("old text", text)
+
+    def test_a_workdir_at_this_version_is_left_alone(self):
+        lb.seed_workdir(self.workdir, "PROMPT", "\n- a rule\n")
+        before = (self.workdir / "CLAUDE.md").stat().st_mtime_ns
+        self.assertFalse(lb.seed_workdir(self.workdir, "PROMPT", "\n- a rule\n"))
+        self.assertEqual((self.workdir / "CLAUDE.md").stat().st_mtime_ns, before)
+
+    def test_an_older_marker_is_replaced(self):
+        self.workdir.mkdir(parents=True)
+        stale = "PROMPT\n\nold\n" + lb.appendix_marker(lb.APPENDIX_VERSION - 1) + "\n"
+        for name in ("AGENTS.md", "CLAUDE.md"):
+            (self.workdir / name).write_text(stale, encoding="utf-8")
+        self.assertTrue(lb.seed_workdir(self.workdir, "PROMPT", "\n- current\n"))
+        self.assertIn(
+            lb.appendix_marker(),
+            (self.workdir / "AGENTS.md").read_text(encoding="utf-8"),
         )
 
 


### PR DESCRIPTION
The two items deferred out of the first batch, both from the trial.

**Mention-only in channels.** The bridge answered every message an allowlisted person sent in the watched channel, which is what made the trial noisy. It now answers a channel message only when the text mentions it, strips its own mention before passing the request on, and treats a bare mention as hello. DMs are unchanged and need no mention.

The bot's user id comes from `auth.test`, needing no extra scope, retried on a slow timer. Until it answers, the channel behaves exactly as before and the log says why. That direction is chosen on purpose: a bot that has gone silent is harder to diagnose than one that is too eager.

**Per-channel formatting.** Ordinary Markdown is wrong on all three channels and differently so: Slack reads `*one asterisk*`, Telegram is sent with no parse mode so nothing renders, WhatsApp uses single markers. An agent writing `**bold**` was putting literal asterisks in front of the reader. The appendix now carries the right dialect per channel, and an unknown channel is told to assume nothing renders.

174 bridge unit tests and the full smoke suite pass. README, the Slack trial guide, and the changelog updated.