### PR TITLE
Say how to name a Telegram bot, and why one each

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ token. Message your bot once, then read your chat id out of
 `TELEGRAM_ALLOWED_CHATS`. The bridge long-polls, so nothing has to be
 reachable from outside.
 
+**One bot per person, named after that person.** Telegram has no workspace, so
+a team does not share a bot: two bridges polling one token make Telegram answer
+409 and fight over the offset, and messages get answered twice or lost. Each
+person makes their own bot on their own machine, so name it so the owner is
+obvious in a list of them:
+
+```
+Display name:  Aigora Mason Lantern
+Username:      aigora_mason_lantern_bot
+```
+
+Telegram requires the username to end in `bot`. `<org>_<person>_lantern_bot`
+keeps them sorted together and makes it plain whose machine a bot reaches,
+which matters because that is exactly what an allowlist entry grants.
+
 The id you took from your own private chat is your user id, and that is what
 the allowlist is for: **a chat id here is a person, not a room.** A group or
 supergroup id would name a room, and the bridge will not answer one — putting


### PR DESCRIPTION
Setting up Telegram, the naming convention was missing and the reason for it was implicit.

Telegram has no workspace, so a team cannot share one bot: two bridges polling one token make Telegram answer 409 and fight over the offset cursor. One bot per person, on that person's own machine, is a requirement rather than a preference.

The README now gives the format, `aigora_mason_lantern_bot`, and says why: an allowlist entry grants a shell on that person's machine, so whose machine a bot reaches should be obvious from its name rather than needing to be looked up.

Docs only. Suite green.