### PR TITLE
Use open-tab language for focus offers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.9.1] - 2026-08-22
+
+### Changed
+
+- Lantern now asks, "Would you like me to open the tab?" when it offers to
+  focus an agent, workspace, or tab. It still accepts the old phrase as an
+  input alias.
+- The plugin version is 0.9.1.
+
 ## [0.9.0] - 2026-08-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.9.0** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.9.1** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.9.0 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.9.1 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.9.0"
+version = "0.9.1"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.0</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.1</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>

--- a/launch.sh
+++ b/launch.sh
@@ -173,8 +173,9 @@ Runtime (injected by launch.sh; do not ignore):
   provider-specific flag and the protections it removes in the gated seat
   plan. Run it only after the user confirms that exact plan.
 - Route loose phrases. "What’s going on" means field status and agent,
-  workspace, and tab lists. "Walk me there" means an exact agent, workspace,
-  or tab focus. "Tell them X" means an exact gated agent prompt. "Open battle
+  workspace, and tab lists. "Open the tab" means an exact agent, workspace,
+  or tab focus. Offer it with, "Would you like me to open the tab?" "Tell
+  them X" means an exact gated agent prompt. "Open battle
   paddle with Codex" means resolve the repo, reuse its workspace, and seat
   Codex. "Second tab same way" means create a tab in that same workspace and
   reuse the last verified kind and model settings. Resume uses the real kind

--- a/prompt.md
+++ b/prompt.md
@@ -1,7 +1,7 @@
 You are Lantern, by Elves — from the team that brought you Elves. Herdr
 manages the herd. The herd is in the field. You illuminate the field:
-which workspace needs attention, what that agent is working toward, walk
-the user to a pane, and start a new agent when they ask. You do not edit
+which workspace needs attention, what that agent is working toward, open
+the user's tab, and start a new agent when they ask. You do not edit
 repos or write code.
 
 Herdr is workspaces, tabs, and panes. An agent is a process it
@@ -19,7 +19,7 @@ list` before you create anything. Reuse the workspace for the same cwd.
 | User language | Verified route | Rule |
 | --- | --- | --- |
 | "what's going on", "status", "show the field" | `herdr status`, `herdr agent list`, `herdr agent read/get/wait/explain`, `herdr workspace list`, `herdr tab list` | Read-only. Use the smallest query that answers the question. |
-| "walk me there", "focus finances" | `herdr agent focus <target>`, `herdr workspace focus <workspace_id>`, or `herdr tab focus <tab_id>` | Confirm the exact target. Then use the mutation gate. |
+| "open the tab", "walk me there", "open finances", "focus finances" | `herdr agent focus <target>`, `herdr workspace focus <workspace_id>`, or `herdr tab focus <tab_id>` | Ask, "Would you like me to open the tab?" Confirm the exact target. Then use the mutation gate. |
 | "open battle paddle with codex", "seat another" | `herdr workspace create --cwd <dir> --label <label> --no-focus`, `herdr agent start <slug> --kind <kind> --pane <pane_id> -- <kind args>`, optional `herdr agent prompt`, then `herdr tab rename` | Confirm the full seat plan. Do not create a second workspace for the same cwd. |
 | "open battle paddle with Cursor" | Seat with `--kind cursor` and the live Cursor model route. | "Cursor" selects the Cursor CLI. |
 | "open battle paddle with Grok" | Seat with `--kind cursor` and a live Cursor Grok model ID. | Bare "Grok" means Grok through Cursor Ultra. |
@@ -286,7 +286,8 @@ words name that task.
      Refresh with: `python3 $HERDR_PLUGIN_ROOT/bin/goals-floor`
    - If they ask what someone is working toward, lead with that file, then
      `herdr agent read <target> --lines 40` if you need the last lines.
-   - `herdr agent focus <target>` walks them there. Confirm, then
+   - `herdr agent focus <target>` opens the tab for them. Ask, "Would you
+     like me to open the tab?" Confirm, then
      `HERDR_HELPER_OK=1`.
 
 Ground rules:

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -172,6 +172,16 @@ for gated_verb in prompt send-keys start focus close remove; do
         fail "the launch.sh appendix does not name $gated_verb as gated"
 done
 
+for route_file in prompt.md launch.sh; do
+    grep -qF 'Would you like me to open the tab?' "$root/$route_file" ||
+        fail "$route_file does not use the open-tab confirmation"
+    if grep -qiF 'Would you like me to walk you there?' "$root/$route_file"; then
+        fail "$route_file still uses the old walk confirmation"
+    fi
+done
+grep -qF '"walk me there"' "$root/prompt.md" ||
+    fail "prompt.md no longer accepts the old input alias"
+
 # Seated agents start in the smart-auto tier. The per-kind flags have to
 # appear everywhere the lantern is told how to start an agent — the prompt
 # and the pane appendix — and the flags that would hand a seated agent the


### PR DESCRIPTION
## Summary

- Change Lantern's focus offer to "Would you like me to open the tab?"
- Keep "walk me there" as an accepted input alias
- Bump the plugin version to 0.9.1
- Add smoke coverage for the new confirmation text

## Test

- `sh tests/smoke.sh`
- `git diff --check`
