### PR TITLE
Seat Codex without the workspace-write sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.9.2] - 2026-08-22
+
+### Changed
+
+- Codex seats no longer use `-s workspace-write`. That sandbox blocks
+  network and writes outside the repo, and with `-a never` those failures
+  never reach the user. Smart-auto for Codex is now `-a never -s
+  danger-full-access`, the same working bar as Claude `--permission-mode
+  auto`. Claude, Grok, and Cursor seats are unchanged. Full bypass flags
+  stay yolo-only.
+- The plugin version is 0.9.2.
+
 ## [0.9.1] - 2026-08-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.9.1** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.9.2** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 
@@ -109,7 +109,7 @@ Mutating `herdr` commands (create, start, focus, close, …) go through
 Agents the lantern seats for you start in the smart-auto permission tier:
 `agent start` passes each kind's own flags after `--` — Claude Code and Grok
 get `--permission-mode auto`, Cursor `agent` gets `--auto-review --trust`,
-Codex gets `-a never -s workspace-write`; kinds without a listed tier get no
+Codex gets `-a never -s danger-full-access`; kinds without a listed tier get no
 extra flags. The flags that skip approvals altogether (bypassPermissions,
 `--yolo`, `--force`, `--always-approve`,
 `--dangerously-bypass-approvals-and-sandbox`) are not part of any default.

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.9.1 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.9.2 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.9.1"
+version = "0.9.2"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.1</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.2</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>

--- a/launch.sh
+++ b/launch.sh
@@ -156,7 +156,7 @@ Runtime (injected by launch.sh; do not ignore):
   effort, then \`grok-4.5\` at high effort. Codex interactive and review
   default to Sol 5.6, high, fast, after the live catalog confirms
   \`-m gpt-5.6-sol -c model_reasoning_effort=\"high\" -c
-  service_tier=\"priority\"\`, plus \`-a never -s workspace-write\`. Use
+  service_tier=\"priority\"\`, plus \`-a never -s danger-full-access\`. Use
   \`\$HERDR_PLUGIN_ROOT/bin/model-route codex "5.6 sol high fast"\` to get
   separate Codex argv. Use the same resolver with cursor or grok for a user
   supplied model phrase. Never invent a model slug. A kind not named here

--- a/prompt.md
+++ b/prompt.md
@@ -71,7 +71,7 @@ For a request such as "have Codex review battle-paddle #166":
    matching agent exists, create a tab in that workspace and use one start
    route below.
 7. Codex uses `herdr agent start <slug> --kind codex --pane <pane_id> --
-   <model args> -a never -s workspace-write review --base <base> "Review PR
+   <model args> -a never -s danger-full-access review --base <base> "Review PR
    #<number>: <title>. Return findings only. Do not edit."`.
 8. Cursor has no review subcommand on this machine. It has read-only plan
    mode. Use `herdr agent start <slug> --kind cursor --pane <pane_id> --
@@ -139,11 +139,11 @@ When the user does not name a model:
 - An explicit user model phrase always wins.
 
 Smart-auto is the default permission tier. Codex uses `-a never -s
-workspace-write`. Claude and Grok use `--permission-mode auto`. Cursor uses
-`--auto-review --trust`. If Codex needs one extra writable directory, add the
-verified `--add-dir <exact-path>` after confirmation. If that is not enough,
-report the rejected operation. Do not escalate to full sandbox bypass.
-Never pass `--dangerously-bypass-approvals-and-sandbox`, `--yolo`, `--force`,
+danger-full-access`. That is the Codex equivalent of Claude
+`--permission-mode auto`: approve and run, without a workspace-only sandbox
+that blocks network and ordinary writes. Claude and Grok use
+`--permission-mode auto`. Cursor uses `--auto-review --trust`. Never pass
+`--dangerously-bypass-approvals-and-sandbox`, `--yolo`, `--force`,
 `--always-approve`, or `bypassPermissions` unless the user explicitly asks
 for yolo in that request. A yolo request does not select every bypass. Name
 the one provider-specific flag and the protections it removes in the gated
@@ -195,7 +195,7 @@ The preflight uses this substitute order. It skips absent or exhausted models:
 | --- | --- |
 | Codex continue last | `codex resume --last` |
 | Codex fork last | `codex fork --last` |
-| Codex review | `codex <model args> -a never -s workspace-write review --uncommitted`, `review --base <branch>`, or `review --commit <sha>` |
+| Codex review | `codex <model args> -a never -s danger-full-access review --uncommitted`, `review --base <branch>`, or `review --commit <sha>` |
 | Codex apply a task diff | `codex apply <TASK_ID>` only when a task ID is known. Route it to a Codex pane. Lantern does not apply it itself. |
 | Codex diagnostics | `codex doctor --summary` and `codex login status`; run interactive `codex login` only when the user asks to fix login. |
 | Claude | `claude --continue` or `claude --resume <id>`; add `--fork-session` only when asked to fork. |
@@ -242,7 +242,7 @@ words name that task.
        grok default: `-- <live model-route grok default argv>
        --permission-mode auto`
        codex default: `-- -m gpt-5.6-sol -c 'model_reasoning_effort="high"'
-       -c 'service_tier="priority"' -a never -s workspace-write`, after the live
+       -c 'service_tier="priority"' -a never -s danger-full-access`, after the live
        resolver confirms that route.
      A kind not listed here gets no extra args. Never pass
      bypassPermissions, --yolo, --force, --always-approve, or

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -190,10 +190,13 @@ grep -qF '"walk me there"' "$root/prompt.md" ||
 # CLI's own dangerous tier, so a grep for it proves nothing.)
 for seat_file in prompt.md launch.sh; do
     for seat_args in '--permission-mode auto' '--auto-review --trust' \
-        '-a never -s workspace-write'; do
+        '-a never -s danger-full-access'; do
         grep -qF -- "$seat_args" "$root/$seat_file" ||
             fail "$seat_file does not pass $seat_args on agent start"
     done
+    if grep -qF -- '-s workspace-write' "$root/$seat_file"; then
+        fail "$seat_file still seats Codex in the workspace-write sandbox"
+    fi
     for reckless in bypassPermissions --yolo --always-approve \
         --dangerously-bypass-approvals-and-sandbox; do
         grep -qF -- "$reckless" "$root/$seat_file" ||


### PR DESCRIPTION
## Summary

- Seat Codex with `-a never -s danger-full-access` instead of `-s workspace-write`
- Keep Claude, Grok, and Cursor smart-auto flags unchanged
- Bump the plugin to 0.9.2 and update the operator docs

The workspace-write sandbox blocked network and writes outside the repo. Combined with `-a never`, those failures never reached the user, so Codex could not do ordinary work. This is the Codex equivalent of Claude `--permission-mode auto`. Full bypass flags stay yolo-only.

## Test plan

- [x] `sh tests/smoke.sh`
- [ ] Confirm CI smoke jobs on Linux, macOS, and Windows
- [ ] After merge, tag `v0.9.2` and publish the GitHub release