### PR TITLE
Accept Claude usage lines that omit a reset time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.9.3] - 2026-08-22
+
+### Fixed
+
+- Claude model-preflight no longer fails when `claude /usage` prints
+  `Current session: 0% used` with no reset time. A usage line is valid
+  without a reset. A missing all-models bucket is not a failed check. Real
+  100% exhaustion and the substitute list are unchanged. Cursor, Grok, and
+  Codex still only need the requested model in their live catalog.
+- The plugin version is 0.9.3.
+
 ## [0.9.2] - 2026-08-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.9.2** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.9.3** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 
@@ -120,8 +120,10 @@ Seat language selects the CLI and model separately. "Cursor" uses `--kind
 cursor` with the live Cursor Sol default. Bare "Grok" uses `--kind cursor`
 with a live Cursor Grok model. "Grok Build" and "SuperGrok" use `--kind
 grok`. Lantern checks the selected model with `bin/model-preflight` before it
-asks you to confirm a seat. It stops on a failed check. It names one live
-substitute when the requested model is unavailable.
+asks you to confirm a seat. It stops on a failed check or a model it knows
+will not work, and names one live substitute. A usage line with no reset
+time is still valid. Missing quota info on a harness that has no usage
+command is not a failed check.
 
 "There is a PR on battle-paddle, get a Codex review" is a review route.
 Lantern resolves the repository and pull request with Git and `gh`. It checks

--- a/bin/model-preflight.py
+++ b/bin/model-preflight.py
@@ -145,6 +145,13 @@ def cursor_sol_substitute() -> dict[str, object] | None:
     return {"kind": "cursor", "model": choice, "effort": "high", "fast": True, "argv": ["--model", choice]}
 
 
+def exhausted_reason(bucket: UsageBucket) -> str:
+    reason = f"{bucket.label} is {bucket.percent}% used"
+    if bucket.reset:
+        reason += f"; resets {bucket.reset}"
+    return reason
+
+
 def parse_claude_usage() -> tuple[str, list[UsageBucket]]:
     try:
         payload = json.loads(run(["claude", "/usage", "-p", "--output-format", "json"]))
@@ -156,18 +163,15 @@ def parse_claude_usage() -> tuple[str, list[UsageBucket]]:
     buckets = []
     limit = re.search(r"hit your\s+(.+?)\s+limit(?:[^\n]*?resets\s+([^\n]+))?", result, re.IGNORECASE)
     if limit:
-        reset = limit.group(2).strip() if limit.group(2) else "unknown"
+        reset = limit.group(2).strip() if limit.group(2) else ""
         buckets.append(UsageBucket(f"Limit: {limit.group(1).strip()}", 100, reset))
     pattern = re.compile(
-        r"^(Current session|Current week \([^)]+\)):\s*(\d+)% used\s*[·-]\s*resets\s+(.+)$",
+        r"^(Current session|Current week \([^)]+\)):\s*(\d+)% used(?:\s*[·•\-]\s*resets\s+(.+))?$",
         re.IGNORECASE | re.MULTILINE,
     )
     for match in pattern.finditer(result):
-        buckets.append(UsageBucket(match.group(1), int(match.group(2)), match.group(3).strip()))
-    labels = {bucket.label.lower() for bucket in buckets}
-    if "current session" not in labels or "current week (all models)" not in labels:
-        if not limit:
-            fail("availability check failed: Claude usage text has no session or all-models bucket")
+        reset = match.group(3).strip() if match.group(3) else ""
+        buckets.append(UsageBucket(match.group(1), int(match.group(2)), reset))
     return result, buckets
 
 
@@ -203,7 +207,7 @@ def claude_capabilities() -> tuple[set[str], set[str]]:
     models = {value.lower() for value in re.findall(r"'([a-zA-Z0-9.-]+)'", model_block.group(0))}
     effort_choices = re.search(r"\((low(?:\s*,\s*(?:medium|high|xhigh|max))+?)\)", effort_block.group(0))
     efforts = set(re.findall(r"low|medium|high|xhigh|max", effort_choices.group(1))) if effort_choices else set()
-    if not {"fable", "opus", "sonnet"} <= models or not efforts:
+    if not models or not efforts:
         fail("availability check failed: Claude returned unparseable model or effort choices")
     return models, efforts
 
@@ -261,15 +265,29 @@ def report_unavailable(kind: str, model: str, reason: str, substitute: dict[str,
 def check(kind: str, model: str, effort: str) -> int:
     if kind == "claude":
         models, efforts = claude_capabilities()
-        if model.lower() not in models:
-            fail(f"availability check failed: Claude model {model} is not verified by claude --help")
-        if effort and effort.lower() not in efforts:
-            fail(f"availability check failed: Claude effort {effort} is not verified by claude --help")
         _, buckets = parse_claude_usage()
+        if model.lower() not in models:
+            return report_unavailable(
+                kind,
+                model,
+                f"Claude model {model} is not verified by claude --help",
+                claude_substitute(model, buckets, models, efforts),
+            )
+        if effort and effort.lower() not in efforts:
+            return report_unavailable(
+                kind,
+                model,
+                f"Claude effort {effort} is not verified by claude --help",
+                claude_substitute(model, buckets, models, efforts),
+            )
         exhausted = exhausted_bucket(model, buckets)
         if exhausted:
-            reason = f"{exhausted.label} is {exhausted.percent}% used; resets {exhausted.reset}"
-            return report_unavailable(kind, model, reason, claude_substitute(model, buckets, models, efforts))
+            return report_unavailable(
+                kind,
+                model,
+                exhausted_reason(exhausted),
+                claude_substitute(model, buckets, models, efforts),
+            )
         return report_available(kind, model, effort)
     if kind == "cursor":
         models = cursor_models()

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.9.2 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.9.3 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.9.2"
+version = "0.9.3"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.2</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.3</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>

--- a/launch.sh
+++ b/launch.sh
@@ -209,9 +209,10 @@ Runtime (injected by launch.sh; do not ignore):
   \`\$HERDR_PLUGIN_ROOT/bin/model-preflight <kind> <model> [effort]\`. Run it
   before asking the user to confirm a seat. Do not create, start, or prompt
   when it fails. A missing command, timeout, or unparseable check stops the
-  route. If the model is unavailable, report its bucket and reset time when
-  known. Name the one live substitute from the result and ask the user to
-  confirm it. Never switch models in silence.
+  route. A usage line with no reset time is still valid. A harness with no
+  quota command is not a failed check. If the model is unavailable, report
+  its bucket and reset time when known. Name the one live substitute from
+  the result and ask the user to confirm it. Never switch models in silence.
 - Model routing requires a working Python 3 command. The wrappers try
   \`python3\`, \`python\`, and Windows \`py -3\`. A missing interpreter stops
   the route before any herd change.

--- a/learnings.md
+++ b/learnings.md
@@ -93,3 +93,9 @@ Stop when the catalog has no one clear ID.
 **A quota check is not an argv check.** Claude usage can prove that a bucket
 has capacity. It cannot prove that a model alias or effort exists. Check both
 the usage result and the installed CLI help before a seat is available.
+
+**A usage line does not need a reset time.** Claude now prints
+`Current session: 0% used` with no reset. Treat the percent as the check.
+Fail only when a parsed bucket is exhausted, the model is absent, or the
+usage command itself failed. Do not require every bucket or a reset just
+to pass. Harnesses with no quota command stay catalog-only.

--- a/prompt.md
+++ b/prompt.md
@@ -164,14 +164,18 @@ workspace, create a tab, or start an agent before this check passes.
 - Claude checks `claude /usage -p --output-format json` and parses the
   `.result` text. A session, all-models, or requested family bucket at 100%
   is unavailable. A result that says the user hit a limit is unavailable.
-  Claude model aliases and effort values must also appear in `claude --help`.
+  A usage line with no reset time is still a valid bucket. Report the reset
+  only when the text has one. Claude model aliases and effort values must
+  also appear in `claude --help`. Do not require every Claude alias, every
+  usage bucket, or a reset time just to pass.
 - Cursor checks the exact ID in `agent --list-models`. It does not scrape a
   dashboard or use account tokens because the CLI has no quota command.
 - Grok Build checks the exact ID in `grok models`. It does not scrape
   grok.com.
 - Codex checks the exact ID in `codex debug models`.
 - If a command is missing, times out, or returns unparseable data, stop and
-  report that the availability check failed. Do not seat on a guess.
+  report that the availability check failed. Do not seat on a guess. A
+  harness with no usage or quota command is not a failed check.
 - The route wrappers require a working Python 3 command. They use `python3`,
   `python`, or the Windows `py -3` launcher. If none works, stop and report
   that Python 3 is required for model routing.

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -241,11 +241,23 @@ cat >"$model_dir/claude" <<'EOF'
 #!/bin/sh
 case "$*" in
 "/usage -p --output-format json")
-    if [ "${CLAUDE_USAGE_MODE-}" = global ]; then
+    case ${CLAUDE_USAGE_MODE-} in
+    global)
         printf '%s\n' '{"result":"You have hit your weekly limit - resets Aug 23 at 4:59am"}'
-    else
+        ;;
+    session-no-reset)
+        printf '%s\n' '{"result":"Current session: 0% used\nCurrent week (all models): 82% used · resets Aug 23 at 5am\nCurrent week (Fable): 100% used · resets Aug 23 at 5am"}'
+        ;;
+    session-only-no-reset)
+        printf '%s\n' '{"result":"Current session: 0% used"}'
+        ;;
+    session-exhausted-no-reset)
+        printf '%s\n' '{"result":"Current session: 100% used"}'
+        ;;
+    *)
         printf '%s\n' '{"result":"Current session: 4% used - resets Aug 22 at 1:19pm\nCurrent week (all models): 82% used - resets Aug 23 at 4:59am\nCurrent week (Fable): 100% used - resets Aug 23 at 4:59am"}'
-    fi
+        ;;
+    esac
     ;;
 "--help")
     cat <<'HELP'
@@ -291,6 +303,18 @@ if "%1"=="--help" (
 if not "%1 %2 %3 %4"=="/usage -p --output-format json" exit /b 2
 if "%CLAUDE_USAGE_MODE%"=="global" (
   echo {"result":"You have hit your weekly limit - resets Aug 23 at 4:59am"}
+  exit /b 0
+)
+if "%CLAUDE_USAGE_MODE%"=="session-no-reset" (
+  echo {"result":"Current session: 0%% used\nCurrent week (all models): 82%% used - resets Aug 23 at 5am\nCurrent week (Fable): 100%% used - resets Aug 23 at 5am"}
+  exit /b 0
+)
+if "%CLAUDE_USAGE_MODE%"=="session-only-no-reset" (
+  echo {"result":"Current session: 0%% used"}
+  exit /b 0
+)
+if "%CLAUDE_USAGE_MODE%"=="session-exhausted-no-reset" (
+  echo {"result":"Current session: 100%% used"}
   exit /b 0
 )
 echo {"result":"Current session: 4%% used - resets Aug 22 at 1:19pm\nCurrent week (all models): 82%% used - resets Aug 23 at 4:59am\nCurrent week (Fable): 100%% used - resets Aug 23 at 4:59am"}
@@ -346,6 +370,39 @@ fi
 if run_model_preflight claude fable ultra >/dev/null 2>&1; then
     fail "Claude preflight accepted an unverified effort"
 fi
+CLAUDE_USAGE_MODE=session-no-reset
+export CLAUDE_USAGE_MODE
+opus_ok=$(run_model_preflight claude opus high) ||
+    fail "Claude preflight rejected Opus when session has no reset time"
+printf '%s\n' "$opus_ok" | grep -qF '"available":true' ||
+    fail "Claude preflight did not treat a session without reset as available"
+if fable_no_reset=$(run_model_preflight claude fable high); then
+    fail "Claude preflight accepted exhausted Fable without a session reset"
+else
+    preflight_status=$?
+fi
+[ "$preflight_status" -eq 3 ] || fail "exhausted Fable without session reset should return unavailable"
+printf '%s\n' "$fable_no_reset" | grep -qF '"reason":"Current week (Fable) is 100% used; resets Aug 23 at 5am"' ||
+    fail "Claude preflight dropped the Fable reset when session had none"
+printf '%s\n' "$fable_no_reset" | grep -qF '"substitute":{"kind":"claude","model":"opus","effort":"xhigh"' ||
+    fail "Claude preflight did not keep the Opus substitute"
+CLAUDE_USAGE_MODE=session-only-no-reset
+opus_session_only=$(run_model_preflight claude opus high) ||
+    fail "Claude preflight required an all-models bucket"
+printf '%s\n' "$opus_session_only" | grep -qF '"available":true' ||
+    fail "Claude preflight did not accept a session-only usage line"
+CLAUDE_USAGE_MODE=session-exhausted-no-reset
+if session_exhausted=$(run_model_preflight claude opus high); then
+    fail "Claude preflight accepted a 100% session with no reset time"
+else
+    preflight_status=$?
+fi
+[ "$preflight_status" -eq 3 ] || fail "100% session without reset should return unavailable"
+printf '%s\n' "$session_exhausted" | grep -qF '"reason":"Current session is 100% used"' ||
+    fail "Claude preflight required a reset time in the exhausted reason"
+printf '%s\n' "$session_exhausted" | grep -qF '"substitute":{"kind":"cursor","model":"gpt-5.6-sol-high-fast"' ||
+    fail "exhausted session did not keep the substitute list"
+unset CLAUDE_USAGE_MODE
 CLAUDE_USAGE_MODE=global
 export CLAUDE_USAGE_MODE
 if global_check=$(run_model_preflight claude fable high); then
@@ -429,6 +486,8 @@ grep -qF '"Grok Build review on XYZ", "have SuperGrok review that PR" | Use the 
 for preflight_file in prompt.md launch.sh README.md; do
     grep -qF 'model-preflight' "$root/$preflight_file" ||
         fail "$preflight_file does not require the availability preflight"
+    grep -qF 'usage line with no reset' "$root/$preflight_file" ||
+        fail "$preflight_file still requires a reset time on Claude usage"
 done
 grep -qF '"Grok" also' "$root/launch.sh" ||
     fail "launch.sh does not route bare Grok through Cursor"


### PR DESCRIPTION
## Summary

- Claude model-preflight now treats `Current session: 0% used` as a valid usage line, even with no reset time
- A missing all-models bucket is not a failed check. Real 100% exhaustion and the substitute list stay in place
- Cursor, Grok, and Codex still only need the requested model in their live catalog. Missing quota info there is non-blocking
- Bump the plugin to 0.9.3

Lantern should not open a chat it knows will not work. It should also not fail a working Opus seat because Claude stopped printing a session reset.

## Test plan

- [x] `sh tests/smoke.sh`
- [ ] Confirm CI smoke jobs on Linux, macOS, and Windows
- [ ] After merge, tag `v0.9.3` and publish the GitHub release