### PR TITLE
Survive Codex first-run trust and new-chat gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.9.4] - 2026-08-22
+
+### Fixed
+
+- Codex seats that stop on the first-run directory trust dialog or a
+  new-chat `[y/n]` confirm no longer die as `agent_not_ready`. The herdr
+  wrapper reads that named pane, sends Enter or y, and waits until the
+  seat is idle and `interactive_ready`. Other start failures, other
+  agents, and later permission prompts are unchanged.
+- The plugin version is 0.9.4.
+
 ## [0.9.3] - 2026-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable changes to Lantern, by Elves are documented here.
 - Codex seats that stop on the first-run directory trust dialog or a
   new-chat `[y/n]` confirm no longer die as `agent_not_ready`. The herdr
   wrapper reads that named pane, sends Enter or y, and waits until the
-  seat is idle and `interactive_ready`. Other start failures, other
-  agents, and later permission prompts are unchanged.
+  seat is idle and `interactive_ready`. Trust and a new-chat confirm in
+  sequence are both dismissed. Other start failures, other agents, and
+  later permission prompts are unchanged.
 - The plugin version is 0.9.4.
 
 ## [0.9.3] - 2026-08-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to Lantern, by Elves are documented here.
 - Codex seats that stop on the first-run directory trust dialog or a
   new-chat `[y/n]` confirm no longer die as `agent_not_ready`. The herdr
   wrapper reads that named pane, sends Enter or y, and waits until the
-  seat is idle and `interactive_ready`. Trust and a new-chat confirm in
-  sequence are both dismissed. Other start failures, other agents, and
-  later permission prompts are unchanged.
+  seat is idle or done and `interactive_ready`. Trust and a new-chat
+  confirm in sequence are both dismissed. Leftover trust text does not
+  replace y. Generic permission `[y/n]` prompts are not auto-answered.
+  The occupant must still be Codex in that pane. Other start failures,
+  other agents, and later permission prompts are unchanged.
 - The plugin version is 0.9.4.
 
 ## [0.9.3] - 2026-08-22

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.9.3** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.9.4** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 

--- a/bin/herdr
+++ b/bin/herdr
@@ -25,6 +25,10 @@ case ${HERDR_HELPER_OK:-} in
         helper_relay_agent_prompt "$real" "$@"
         exit $?
     fi
+    if helper_is_agent_start "$@"; then
+        helper_relay_agent_start "$real" "$@"
+        exit $?
+    fi
     exec "$real" "$@"
     ;;
 esac

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.9.3 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.9.4 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.9.3"
+version = "0.9.4"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.3</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.4</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>

--- a/launch.sh
+++ b/launch.sh
@@ -146,7 +146,8 @@ Runtime (injected by launch.sh; do not ignore):
 - \`herdr agent start\` through the wrapper, for Codex only, dismisses the
   first-run directory trust dialog with Enter or a new-chat \`[y/n]\` /
   \`yes (y)\` confirm with y when Herdr returns \`agent_not_ready\` /
-  blocked during startup on that named pane. It waits until idle and
+  blocked during startup on that named pane. If both appear, it dismisses
+  them in order. It waits until idle and
   \`interactive_ready\`. It does not send keys into any other failure,
   another agent’s pane, or later permission prompts.
 - This chat runs $chat_identity. Name that in your light-up line — it is

--- a/launch.sh
+++ b/launch.sh
@@ -143,6 +143,12 @@ Runtime (injected by launch.sh; do not ignore):
   (Cursor often types into the follow-up field without submitting), and
   it fails when nothing shows the message went in. Read the pane before
   saying sent.
+- \`herdr agent start\` through the wrapper, for Codex only, dismisses the
+  first-run directory trust dialog with Enter or a new-chat \`[y/n]\` /
+  \`yes (y)\` confirm with y when Herdr returns \`agent_not_ready\` /
+  blocked during startup on that named pane. It waits until idle and
+  \`interactive_ready\`. It does not send keys into any other failure,
+  another agent’s pane, or later permission prompts.
 - This chat runs $chat_identity. Name that in your light-up line — it is
   how the user tells which CLI and model is answering — and repeat it
   whenever they ask.

--- a/launch.sh
+++ b/launch.sh
@@ -147,7 +147,7 @@ Runtime (injected by launch.sh; do not ignore):
   first-run directory trust dialog with Enter or a new-chat \`[y/n]\` /
   \`yes (y)\` confirm with y when Herdr returns \`agent_not_ready\` /
   blocked during startup on that named pane. If both appear, it dismisses
-  them in order. It waits until idle and
+  them in order. It waits until idle or done and
   \`interactive_ready\`. It does not send keys into any other failure,
   another agent’s pane, or later permission prompts.
 - This chat runs $chat_identity. Name that in your light-up line — it is

--- a/lib.sh
+++ b/lib.sh
@@ -524,37 +524,87 @@ helper_relay_agent_prompt() {
     return 0
 }
 
-helper_codex_startup_key() {
-    # Prints Enter or y when pane text ($1) is a Codex first-run gate.
-    # Newlines are flattened so a wrapped trust question still matches.
-    # Later permission prompts are not a match: those are not a first-run
-    # gate, and sending y into one would approve work nobody asked to skip.
-    _helper_flat=$(printf '%s\n' "$1" | tr '\n\r' '  ')
+helper_codex_flat_pane() {
+    printf '%s\n' "$1" | tr '\n\r' '  '
+}
+
+helper_codex_pane_is_later_prompt() {
+    # True when the pane is a later permission prompt, not a first-run gate.
+    _helper_flat=$(helper_codex_flat_pane "$1")
     case $_helper_flat in
     *"Allow command[?]"* | *"allow command[?]"* | \
         *"press enter to confirm or esc to cancel"*)
-        return 1
-        ;;
-    esac
-    case $_helper_flat in
-    *"Do you trust the contents of this directory"* | *"Yes, continue"*)
-        printf 'Enter'
-        return 0
-        ;;
-    *'[y/n]'* | *'yes (y)'* | *'Yes (y)'*)
-        printf 'y'
         return 0
         ;;
     esac
     return 1
 }
 
-helper_codex_is_ready() {
-    # True when agent get JSON ($1) says the seat can take prompts.
-    case $1 in
-    *"\"interactive_ready\":true"*) return 0 ;;
+helper_codex_pane_has_trust() {
+    helper_codex_pane_is_later_prompt "$1" && return 1
+    _helper_flat=$(helper_codex_flat_pane "$1")
+    case $_helper_flat in
+    *"Do you trust the contents of this directory"* | *"Yes, continue"*)
+        return 0
+        ;;
     esac
     return 1
+}
+
+helper_codex_pane_has_yn() {
+    helper_codex_pane_is_later_prompt "$1" && return 1
+    _helper_flat=$(helper_codex_flat_pane "$1")
+    case $_helper_flat in
+    *'[y/n]'* | *'yes (y)'* | *'Yes (y)'*) ;;
+    *) return 1 ;;
+    esac
+    case $_helper_flat in
+    *[Nn]ew\ chat* | *[Nn]ew-chat* | *[Nn]ew\ conversation* | \
+        *[Rr]esume\ this\ session*)
+        return 0
+        ;;
+    esac
+    return 1
+}
+
+helper_codex_startup_key() {
+    # Prints Enter or y when pane text ($1) is a Codex first-run gate.
+    # Trust wins when both are visible on the first key. Later permission
+    # prompts are not a match.
+    helper_codex_pane_is_later_prompt "$1" && return 1
+    helper_codex_pane_has_trust "$1" && {
+        printf 'Enter'
+        return 0
+    }
+    helper_codex_pane_has_yn "$1" && {
+        printf 'y'
+        return 0
+    }
+    return 1
+}
+
+helper_codex_is_ready() {
+    # True when agent get JSON ($1) says the seat can take prompts.
+    # Unfocused new seats report done rather than idle, so both count.
+    case $1 in
+    *"\"interactive_ready\":true"*) ;;
+    *) return 1 ;;
+    esac
+    case $1 in
+    *"\"agent_status\":\"idle\""* | *"\"agent_status\":\"done\""*)
+        return 0
+        ;;
+    esac
+    return 1
+}
+
+helper_codex_seat_ok() {
+    # True when agent get JSON ($1) is still the Codex seat in pane ($2).
+    _helper_got_pane=$(printf '%s' "$1" | helper_json_value pane_id)
+    [ "$_helper_got_pane" = "$2" ] || return 1
+    _helper_got_agent=$(printf '%s' "$1" | helper_json_value agent)
+    [ "$_helper_got_agent" = codex ] || return 1
+    return 0
 }
 
 helper_relay_agent_start() {
@@ -588,45 +638,89 @@ helper_relay_agent_start() {
     esac
     _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
         return $_helper_status
-    _helper_got_pane=$(printf '%s' "$_helper_got" | helper_json_value pane_id)
-    [ "$_helper_got_pane" = "$_helper_pane" ] || return $_helper_status
+    helper_codex_seat_ok "$_helper_got" "$_helper_pane" || return $_helper_status
     _helper_sent=0
     _helper_miss=0
-    _helper_prev=
+    _helper_post_miss=0
+    _helper_did_trust=0
+    _helper_did_y=0
+    _helper_did_yn_enter=0
     while [ "$_helper_sent" -lt 3 ]; do
         _helper_before=$("$_helper_real" agent read "$_helper_name" --lines 60 2>/dev/null) ||
             _helper_before=
-        _helper_key=$(helper_codex_startup_key "$_helper_before") || {
+        if helper_codex_pane_is_later_prompt "$_helper_before"; then
+            [ "$_helper_sent" -gt 0 ] && break
+            return $_helper_status
+        fi
+        _helper_key=
+        if helper_codex_pane_has_yn "$_helper_before" &&
+            [ "$_helper_did_y" -eq 1 ] && [ "$_helper_did_yn_enter" -eq 0 ]; then
+            _helper_key=Enter
+        elif helper_codex_pane_has_yn "$_helper_before" &&
+            [ "$_helper_did_y" -eq 0 ] &&
+            { [ "$_helper_did_trust" -eq 1 ] ||
+                ! helper_codex_pane_has_trust "$_helper_before"; }; then
+            _helper_key=y
+        elif helper_codex_pane_has_trust "$_helper_before" &&
+            [ "$_helper_did_trust" -eq 0 ]; then
+            _helper_key=Enter
+        elif helper_codex_pane_has_yn "$_helper_before" &&
+            [ "$_helper_did_y" -eq 0 ]; then
+            _helper_key=y
+        fi
+        if [ -z "$_helper_key" ]; then
+            _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
+                _helper_got=
+            helper_codex_seat_ok "$_helper_got" "$_helper_pane" || {
+                [ "$_helper_sent" -gt 0 ] && break
+                return $_helper_status
+            }
+            helper_codex_is_ready "$_helper_got" && return 0
             if [ "$_helper_sent" -gt 0 ]; then
-                break
+                _helper_post_miss=$((_helper_post_miss + 1))
+                [ "$_helper_post_miss" -ge 3 ] && break
+                "$_helper_real" agent wait "$_helper_name" --until idle --until done \
+                    --timeout 2000 >/dev/null 2>&1 || true
+                continue
             fi
             _helper_miss=$((_helper_miss + 1))
             [ "$_helper_miss" -ge 2 ] && return $_helper_status
             # Herdr already called it blocked; the dialog may still be
             # painting. --until idle times out while it stays blocked.
-            "$_helper_real" agent wait "$_helper_name" --until idle --timeout 2000 \
-                >/dev/null 2>&1 || true
+            "$_helper_real" agent wait "$_helper_name" --until idle --until done \
+                --timeout 2000 >/dev/null 2>&1 || true
             continue
-        }
-        if [ "$_helper_key" = y ] && [ "$_helper_prev" = y ]; then
-            _helper_key=Enter
         fi
+        _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
+            return $_helper_status
+        helper_codex_seat_ok "$_helper_got" "$_helper_pane" || return $_helper_status
         "$_helper_real" agent send-keys "$_helper_name" "$_helper_key" || return $?
         _helper_sent=$((_helper_sent + 1))
-        _helper_prev=$_helper_key
-        if "$_helper_real" agent wait "$_helper_name" --until idle --timeout 5000; then
+        _helper_post_miss=0
+        if [ "$_helper_key" = y ]; then
+            _helper_did_y=1
+        elif [ "$_helper_did_y" -eq 1 ]; then
+            _helper_did_yn_enter=1
+        else
+            _helper_did_trust=1
+        fi
+        if "$_helper_real" agent wait "$_helper_name" --until idle --until done \
+            --timeout 5000; then
             _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
                 _helper_got=
+            helper_codex_seat_ok "$_helper_got" "$_helper_pane" || return 1
             helper_codex_is_ready "$_helper_got" && return 0
         fi
     done
     [ "$_helper_sent" -gt 0 ] || return $_helper_status
-    "$_helper_real" agent wait "$_helper_name" --until idle --timeout 120000 ||
+    "$_helper_real" agent wait "$_helper_name" --until idle --until done \
+        --timeout 120000 ||
         return $?
     _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) || {
         printf '%s\n' "lantern: Codex in $_helper_name did not become ready after the startup gate" >&2
         return 1
     }
+    helper_codex_seat_ok "$_helper_got" "$_helper_pane" || return 1
     helper_codex_is_ready "$_helper_got" && return 0
     printf '%s\n' "lantern: Codex in $_helper_name did not become ready after the startup gate" >&2
     return 1

--- a/lib.sh
+++ b/lib.sh
@@ -549,12 +549,22 @@ helper_codex_startup_key() {
     return 1
 }
 
+helper_codex_is_ready() {
+    # True when agent get JSON ($1) says the seat can take prompts.
+    case $1 in
+    *"\"interactive_ready\":true"*) return 0 ;;
+    esac
+    return 1
+}
+
 helper_relay_agent_start() {
     # Codex first-run survival. Herdr returns agent_not_ready as soon as
     # detection reports blocked during startup, so a directory-trust or
-    # new-chat confirm kills the seat. This reads that same named pane
-    # and sends only the key that gate wants. Any other failure, another
-    # kind, or another agent's pane is left alone.
+    # new-chat confirm kills the seat. Trust and a new-chat confirm can
+    # appear in sequence, and a [y/n] prompt may still need Enter after
+    # y. This stays on that same named pane and sends only those keys.
+    # Any other failure, another kind, or another agent's pane is left
+    # alone.
     _helper_real=$1
     shift
     _helper_name=$3
@@ -580,20 +590,44 @@ helper_relay_agent_start() {
         return $_helper_status
     _helper_got_pane=$(printf '%s' "$_helper_got" | helper_json_value pane_id)
     [ "$_helper_got_pane" = "$_helper_pane" ] || return $_helper_status
-    _helper_before=$("$_helper_real" agent read "$_helper_name" --lines 60 2>/dev/null) ||
-        _helper_before=
-    _helper_key=$(helper_codex_startup_key "$_helper_before") ||
-        return $_helper_status
-    "$_helper_real" agent send-keys "$_helper_name" "$_helper_key" || return $?
+    _helper_sent=0
+    _helper_miss=0
+    _helper_prev=
+    while [ "$_helper_sent" -lt 3 ]; do
+        _helper_before=$("$_helper_real" agent read "$_helper_name" --lines 60 2>/dev/null) ||
+            _helper_before=
+        _helper_key=$(helper_codex_startup_key "$_helper_before") || {
+            if [ "$_helper_sent" -gt 0 ]; then
+                break
+            fi
+            _helper_miss=$((_helper_miss + 1))
+            [ "$_helper_miss" -ge 2 ] && return $_helper_status
+            # Herdr already called it blocked; the dialog may still be
+            # painting. --until idle times out while it stays blocked.
+            "$_helper_real" agent wait "$_helper_name" --until idle --timeout 2000 \
+                >/dev/null 2>&1 || true
+            continue
+        }
+        if [ "$_helper_key" = y ] && [ "$_helper_prev" = y ]; then
+            _helper_key=Enter
+        fi
+        "$_helper_real" agent send-keys "$_helper_name" "$_helper_key" || return $?
+        _helper_sent=$((_helper_sent + 1))
+        _helper_prev=$_helper_key
+        if "$_helper_real" agent wait "$_helper_name" --until idle --timeout 5000; then
+            _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
+                _helper_got=
+            helper_codex_is_ready "$_helper_got" && return 0
+        fi
+    done
+    [ "$_helper_sent" -gt 0 ] || return $_helper_status
     "$_helper_real" agent wait "$_helper_name" --until idle --timeout 120000 ||
         return $?
     _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) || {
         printf '%s\n' "lantern: Codex in $_helper_name did not become ready after the startup gate" >&2
         return 1
     }
-    case $_helper_got in
-    *"\"interactive_ready\":true"*) return 0 ;;
-    esac
+    helper_codex_is_ready "$_helper_got" && return 0
     printf '%s\n' "lantern: Codex in $_helper_name did not become ready after the startup gate" >&2
     return 1
 }

--- a/lib.sh
+++ b/lib.sh
@@ -435,8 +435,40 @@ helper_argv_has_flag() {
     return 1
 }
 
+helper_argv_option_value() {
+    # Print the value of --flag from an argv list. Stops at -- so agent
+    # args cannot supply a fake kind or pane. Accepts --flag value and
+    # --flag=value.
+    _helper_opt=$1
+    shift
+    while [ $# -gt 0 ]; do
+        [ "$1" = -- ] && return 1
+        if [ "$1" = "$_helper_opt" ]; then
+            [ -n "${2:-}" ] || return 1
+            printf '%s' "$2"
+            return 0
+        fi
+        case $1 in
+        "$_helper_opt"=*)
+            printf '%s' "${1#"$_helper_opt"=}"
+            return 0
+            ;;
+        esac
+        shift
+    done
+    return 1
+}
+
 helper_is_agent_prompt() {
     [ "${1:-}" = agent ] && [ "${2:-}" = prompt ] && [ -n "${3:-}" ] && [ -n "${4:-}" ]
+}
+
+helper_is_agent_start() {
+    [ "${1:-}" = agent ] && [ "${2:-}" = start ] && [ -n "${3:-}" ] || return 1
+    case $3 in
+    -*) return 1 ;;
+    esac
+    return 0
 }
 
 helper_pane_holds_text() {
@@ -490,6 +522,80 @@ helper_relay_agent_prompt() {
         return 1
     fi
     return 0
+}
+
+helper_codex_startup_key() {
+    # Prints Enter or y when pane text ($1) is a Codex first-run gate.
+    # Newlines are flattened so a wrapped trust question still matches.
+    # Later permission prompts are not a match: those are not a first-run
+    # gate, and sending y into one would approve work nobody asked to skip.
+    _helper_flat=$(printf '%s\n' "$1" | tr '\n\r' '  ')
+    case $_helper_flat in
+    *"Allow command[?]"* | *"allow command[?]"* | \
+        *"press enter to confirm or esc to cancel"*)
+        return 1
+        ;;
+    esac
+    case $_helper_flat in
+    *"Do you trust the contents of this directory"* | *"Yes, continue"*)
+        printf 'Enter'
+        return 0
+        ;;
+    *'[y/n]'* | *'yes (y)'* | *'Yes (y)'*)
+        printf 'y'
+        return 0
+        ;;
+    esac
+    return 1
+}
+
+helper_relay_agent_start() {
+    # Codex first-run survival. Herdr returns agent_not_ready as soon as
+    # detection reports blocked during startup, so a directory-trust or
+    # new-chat confirm kills the seat. This reads that same named pane
+    # and sends only the key that gate wants. Any other failure, another
+    # kind, or another agent's pane is left alone.
+    _helper_real=$1
+    shift
+    _helper_name=$3
+    _helper_kind=$(helper_argv_option_value --kind "$@") || _helper_kind=
+    _helper_pane=$(helper_argv_option_value --pane "$@") || _helper_pane=
+    _helper_errf=$(mktemp) || {
+        "$_helper_real" "$@"
+        return $?
+    }
+    "$_helper_real" "$@" 2>"$_helper_errf"
+    _helper_status=$?
+    _helper_err=$(cat "$_helper_errf")
+    cat "$_helper_errf" >&2
+    rm -f "$_helper_errf"
+    [ "$_helper_status" -eq 0 ] && return 0
+    [ "$_helper_kind" = codex ] || return $_helper_status
+    [ -n "$_helper_name" ] && [ -n "$_helper_pane" ] || return $_helper_status
+    case $_helper_err in
+    *agent_not_ready* | *"blocked during startup"*) ;;
+    *) return $_helper_status ;;
+    esac
+    _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
+        return $_helper_status
+    _helper_got_pane=$(printf '%s' "$_helper_got" | helper_json_value pane_id)
+    [ "$_helper_got_pane" = "$_helper_pane" ] || return $_helper_status
+    _helper_before=$("$_helper_real" agent read "$_helper_name" --lines 60 2>/dev/null) ||
+        _helper_before=
+    _helper_key=$(helper_codex_startup_key "$_helper_before") ||
+        return $_helper_status
+    "$_helper_real" agent send-keys "$_helper_name" "$_helper_key" || return $?
+    "$_helper_real" agent wait "$_helper_name" --until idle --timeout 120000 ||
+        return $?
+    _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) || {
+        printf '%s\n' "lantern: Codex in $_helper_name did not become ready after the startup gate" >&2
+        return 1
+    }
+    case $_helper_got in
+    *"\"interactive_ready\":true"*) return 0 ;;
+    esac
+    printf '%s\n' "lantern: Codex in $_helper_name did not become ready after the startup gate" >&2
+    return 1
 }
 
 helper_json_value() {

--- a/prompt.md
+++ b/prompt.md
@@ -236,7 +236,7 @@ words name that task.
      directory trust dialog with Enter, or a new-chat `[y/n]` / `yes (y)`
      confirm with y, only when Herdr returns `agent_not_ready` / blocked
      during startup on that same named pane. If both appear, it dismisses
-     them in order. It then waits until idle and
+     them in order. It then waits until idle or done and
      `interactive_ready`. It does not send keys into any other failure,
      another agent's pane, or later permission prompts. Do not send y or
      Enter yourself for those startup gates.

--- a/prompt.md
+++ b/prompt.md
@@ -232,6 +232,13 @@ words name that task.
      the input field (common on Cursor), sends Enter and waits again. It
      fails rather than guess when nothing shows the message went in.
      Read the pane before telling the user it was sent.
+     For Codex, `agent start` through the wrapper dismisses the first-run
+     directory trust dialog with Enter, or a new-chat `[y/n]` / `yes (y)`
+     confirm with y, only when Herdr returns `agent_not_ready` / blocked
+     during startup on that same named pane. It then waits until idle and
+     `interactive_ready`. It does not send keys into any other failure,
+     another agent's pane, or later permission prompts. Do not send y or
+     Enter yourself for those startup gates.
    - To seat: `herdr workspace create --cwd <dir> --label <label> --no-focus`
      (JSON: `.result.root_pane.pane_id`), then
      `herdr agent start <slug> --kind <kind> --pane <pane_id>`, optionally

--- a/prompt.md
+++ b/prompt.md
@@ -235,7 +235,8 @@ words name that task.
      For Codex, `agent start` through the wrapper dismisses the first-run
      directory trust dialog with Enter, or a new-chat `[y/n]` / `yes (y)`
      confirm with y, only when Herdr returns `agent_not_ready` / blocked
-     during startup on that same named pane. It then waits until idle and
+     during startup on that same named pane. If both appear, it dismisses
+     them in order. It then waits until idle and
      `interactive_ready`. It does not send keys into any other failure,
      another agent's pane, or later permission prompts. Do not send y or
      Enter yourself for those startup gates.

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1052,9 +1052,29 @@ fake_prompt=
     fail "[y/n] new-chat confirm should send y"
 [ "$(helper_codex_startup_key 'Resume this session? yes (y)')" = y ] ||
     fail "yes (y) new-chat confirm should send y"
-if helper_codex_startup_key 'Allow command?' >/dev/null; then
-    fail "a later permission prompt must not look like a first-run gate"
+[ "$(helper_codex_startup_key "$(printf '%s\n' \
+    'Do you trust the contents of this directory?' \
+    'Yes, continue' \
+    'Start a new chat? [y/n]')")" = Enter ] ||
+    fail "trust should win the first key when both gates are visible"
+if helper_codex_startup_key 'Would you like to run setup.sh? [y/n]' >/dev/null; then
+    fail "a permission [y/n] must not look like a new-chat confirm"
 fi
+if helper_codex_startup_key 'Approve MCP server startup? yes (y)' >/dev/null; then
+    fail "a permission yes (y) must not look like a new-chat confirm"
+fi
+helper_codex_is_ready '{"interactive_ready":true,"agent_status":"idle"}' ||
+    fail "idle plus interactive_ready should be ready"
+helper_codex_is_ready '{"interactive_ready":true,"agent_status":"done"}' ||
+    fail "done plus interactive_ready should be ready"
+if helper_codex_is_ready '{"interactive_ready":true,"agent_status":"blocked"}'; then
+    fail "blocked plus interactive_ready must not count as seated"
+fi
+if helper_codex_seat_ok '{"agent":"claude","pane_id":"w1:p1"}' w1:p1; then
+    fail "a Claude occupant must not count as the Codex seat"
+fi
+helper_codex_seat_ok '{"agent":"codex","pane_id":"w1:p1"}' w1:p1 ||
+    fail "a Codex occupant in the start pane should count"
 if helper_codex_startup_key 'press enter to confirm or esc to cancel' >/dev/null; then
     fail "a later confirm prompt must not look like a first-run gate"
 fi
@@ -1089,9 +1109,11 @@ case "$1 $2" in
     ;;
 "agent get")
     ready=false
-    [ -f "${FAKE_READY_FILE:-}" ] && ready=true
-    printf '{"result":{"agent":{"pane_id":"%s","interactive_ready":%s,"agent_status":"blocked"}}}\n' \
-        "${FAKE_AGENT_PANE:-w1:p1}" "$ready"
+    status=blocked
+    [ -f "${FAKE_READY_FILE:-}" ] && ready=true && status=idle
+    [ -n "${FAKE_GET_STATUS:-}" ] && status=$FAKE_GET_STATUS
+    printf '{"result":{"agent":{"pane_id":"%s","agent":"%s","interactive_ready":%s,"agent_status":"%s"}}}\n' \
+        "${FAKE_AGENT_PANE:-w1:p1}" "${FAKE_GET_AGENT:-codex}" "$ready" "$status"
     exit 0
     ;;
 "agent read")
@@ -1099,6 +1121,11 @@ case "$1 $2" in
     [ -f "${FAKE_READ_N:-}" ] && n=$(cat "$FAKE_READ_N")
     n=$((n + 1))
     [ -n "${FAKE_READ_N:-}" ] && printf '%s\n' "$n" >"$FAKE_READ_N"
+    if [ -n "${FAKE_PANE_AFTER:-}" ] && [ -f "$FAKE_PANE_AFTER" ] &&
+        [ "$n" -ge "${FAKE_SWAP_AT:-999}" ]; then
+        cat "$FAKE_PANE_AFTER"
+        exit 0
+    fi
     if [ "$n" -eq 1 ] && [ -n "${FAKE_PANE_DELAY:-}" ] && [ -f "$FAKE_PANE_DELAY" ]; then
         cat "$FAKE_PANE_DELAY"
         exit 0
@@ -1138,6 +1165,10 @@ export HERDR_HELPER_OK=1
 export FAKE_PANE="$fake_start/pane.txt"
 export FAKE_PANE_NEXT="$fake_start/pane.next"
 export FAKE_PANE_DELAY="$fake_start/pane.delay"
+export FAKE_PANE_AFTER="$fake_start/pane.after"
+export FAKE_SWAP_AT=999
+export FAKE_GET_AGENT=codex
+unset FAKE_GET_STATUS
 export FAKE_READ_N="$fake_start/read.n"
 export FAKE_HOLD_FILE="$fake_start/hold"
 export FAKE_READY_FILE="$fake_start/ready"
@@ -1184,6 +1215,54 @@ printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
     fail "sequential gates did not send Enter for trust"
 printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
     fail "sequential gates did not send y for new-chat"
+
+# Leftover trust text in the pane must not send a second Enter instead of y.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N" "$FAKE_HOLD_FILE"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' \
+    'Start a new chat? [y/n]' >"$FAKE_PANE_NEXT"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "leftover trust text should still send y for new-chat"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
+    fail "leftover trust text ate the new-chat y"
+[ "$(printf '%s\n' "$out" | grep -c 'agent send-keys reviewer Enter')" -eq 1 ] ||
+    fail "leftover trust text sent Enter more than once"
+
+# After trust, a blank transition, then the new-chat confirm.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N" "$FAKE_HOLD_FILE"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+printf '%s\n' 'codex is starting...' >"$FAKE_PANE_NEXT"
+printf '%s\n' 'Start a new chat? [y/n]' >"$FAKE_PANE_AFTER"
+export FAKE_SWAP_AT=3
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "a delayed second gate should still recover"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "delayed second gate did not send Enter for trust"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
+    fail "delayed second gate did not send y after the blank"
+export FAKE_SWAP_AT=999
+rm -f "$FAKE_PANE_AFTER" "$FAKE_PANE_NEXT"
+
+# A live Claude occupant in that pane must not receive keys.
+export FAKE_GET_AGENT=claude
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a Claude occupant must not be reported as a Codex seat"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a Claude occupant must not receive Codex startup keys"
+fi
+export FAKE_GET_AGENT=codex
 
 # Trust, then a [y/n] that still needs Enter.
 rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
@@ -1313,10 +1392,14 @@ unset FAKE_START_DEAF
 unset FAKE_PANE
 unset FAKE_PANE_NEXT
 unset FAKE_PANE_DELAY
+unset FAKE_PANE_AFTER
+unset FAKE_SWAP_AT
 unset FAKE_READ_N
 unset FAKE_HOLD_FILE
 unset FAKE_READY_FILE
 unset FAKE_AGENT_PANE
+unset FAKE_GET_AGENT
+unset FAKE_GET_STATUS
 unset FAKE_START_ERR
 unset FAKE_START_OK
 unset HERDR_REAL

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1095,17 +1095,38 @@ case "$1 $2" in
     exit 0
     ;;
 "agent read")
+    n=0
+    [ -f "${FAKE_READ_N:-}" ] && n=$(cat "$FAKE_READ_N")
+    n=$((n + 1))
+    [ -n "${FAKE_READ_N:-}" ] && printf '%s\n' "$n" >"$FAKE_READ_N"
+    if [ "$n" -eq 1 ] && [ -n "${FAKE_PANE_DELAY:-}" ] && [ -f "$FAKE_PANE_DELAY" ]; then
+        cat "$FAKE_PANE_DELAY"
+        exit 0
+    fi
     cat "$FAKE_PANE" 2>/dev/null
     exit 0
     ;;
 "agent send-keys")
     printf 'agent send-keys %s %s\n' "$3" "$4"
+    if [ -n "${FAKE_PANE_NEXT:-}" ] && [ -f "$FAKE_PANE_NEXT" ]; then
+        cat "$FAKE_PANE_NEXT" >"$FAKE_PANE"
+        rm -f "$FAKE_PANE_NEXT"
+        exit 0
+    fi
+    if [ -n "${FAKE_HOLD_FILE:-}" ] && [ -f "$FAKE_HOLD_FILE" ]; then
+        rm -f "$FAKE_HOLD_FILE"
+        exit 0
+    fi
     [ -n "${FAKE_START_DEAF:-}" ] || : >"${FAKE_READY_FILE:-/dev/null}"
     exit 0
     ;;
 "agent wait")
     printf '%s\n' "$*"
-    exit 0
+    case "$*" in
+    *"--timeout 120000"*) exit 0 ;;
+    esac
+    [ -f "${FAKE_READY_FILE:-}" ] && exit 0
+    exit 1
     ;;
 esac
 printf '%s\n' "$*"
@@ -1115,13 +1136,17 @@ chmod +x "$fake_start/herdr"
 export HERDR_REAL="$fake_start/herdr"
 export HERDR_HELPER_OK=1
 export FAKE_PANE="$fake_start/pane.txt"
+export FAKE_PANE_NEXT="$fake_start/pane.next"
+export FAKE_PANE_DELAY="$fake_start/pane.delay"
+export FAKE_READ_N="$fake_start/read.n"
+export FAKE_HOLD_FILE="$fake_start/hold"
 export FAKE_READY_FILE="$fake_start/ready"
 export FAKE_AGENT_PANE=w1:p1
 export FAKE_START_ERR=agent_not_ready
 unset FAKE_START_OK
 unset FAKE_START_DEAF
 : >"$FAKE_PANE"
-rm -f "$FAKE_READY_FILE"
+rm -f "$FAKE_READY_FILE" "$FAKE_PANE_NEXT" "$FAKE_PANE_DELAY" "$FAKE_READ_N" "$FAKE_HOLD_FILE"
 
 printf '%s\n' '> You are in /tmp/demo' \
     'Do you trust the contents of this directory?' \
@@ -1146,6 +1171,59 @@ out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev
     fail "Codex yes (y) confirm should recover after y"
 printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
     fail "Codex yes (y) confirm did not send y"
+
+# Trust then a new-chat confirm: one key is not enough.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+printf '%s\n' 'Start a new chat? [y/n]' >"$FAKE_PANE_NEXT"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "trust then new-chat should recover after both keys"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "sequential gates did not send Enter for trust"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
+    fail "sequential gates did not send y for new-chat"
+
+# Trust, then a [y/n] that still needs Enter.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+printf '%s\n' 'Start a new chat? [y/n]' >"$FAKE_PANE_NEXT"
+: >"$FAKE_HOLD_FILE"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "trust then stuck [y/n] should recover after Enter"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "trust then stuck [y/n] did not send Enter"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
+    fail "trust then stuck [y/n] did not send y"
+# Enter, y, Enter — the last Enter is the one that submits [y/n].
+[ "$(printf '%s\n' "$out" | grep -c 'agent send-keys reviewer Enter')" -ge 2 ] ||
+    fail "trust then stuck [y/n] should send Enter twice"
+
+# A [y/n] that does not submit on y still needs Enter.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N" "$FAKE_PANE_NEXT"
+: >"$FAKE_HOLD_FILE"
+printf '%s\n' 'Start a new chat? [y/n]' >"$FAKE_PANE"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "a [y/n] that stayed up should recover after Enter"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
+    fail "stuck [y/n] did not send y first"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "stuck [y/n] did not send Enter after y"
+
+# The dialog may still be painting when Herdr first reports blocked.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N" "$FAKE_HOLD_FILE"
+printf '%s\n' 'codex is starting...' >"$FAKE_PANE_DELAY"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "a delayed trust dialog should still recover"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "a delayed trust dialog did not send Enter"
+rm -f "$FAKE_PANE_DELAY"
 
 # A successful start must not send keys.
 export FAKE_START_OK=1
@@ -1233,6 +1311,10 @@ grep -q 'did not become ready' "$err" ||
 unset FAKE_START_DEAF
 
 unset FAKE_PANE
+unset FAKE_PANE_NEXT
+unset FAKE_PANE_DELAY
+unset FAKE_READ_N
+unset FAKE_HOLD_FILE
 unset FAKE_READY_FILE
 unset FAKE_AGENT_PANE
 unset FAKE_START_ERR

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -20,6 +20,7 @@ tmp=$(mktemp)
 err=$(mktemp)
 fake=
 fake_prompt=
+fake_start=
 fake_ws=
 fake_cmd=
 fake_py=
@@ -29,7 +30,7 @@ open_dir=
 elves_tmp=
 update_dir=
 model_dir=
-trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$fake_cmd" ] && rm -rf "$fake_cmd"; [ -n "$fake_py" ] && rm -rf "$fake_py"; [ -n "$fake_agents" ] && rm -rf "$fake_agents"; [ -n "$argv_dir" ] && rm -rf "$argv_dir"; [ -n "$open_dir" ] && rm -rf "$open_dir"; [ -n "$elves_tmp" ] && rm -rf "$elves_tmp"; [ -n "$update_dir" ] && rm -rf "$update_dir"; [ -n "$model_dir" ] && rm -rf "$model_dir"' EXIT
+trap 'rm -f "$tmp" "$err"; [ -n "$fake" ] && rm -rf "$fake"; [ -n "$fake_prompt" ] && rm -rf "$fake_prompt"; [ -n "$fake_start" ] && rm -rf "$fake_start"; [ -n "$fake_ws" ] && rm -rf "$fake_ws"; [ -n "$fake_cmd" ] && rm -rf "$fake_cmd"; [ -n "$fake_py" ] && rm -rf "$fake_py"; [ -n "$fake_agents" ] && rm -rf "$fake_agents"; [ -n "$argv_dir" ] && rm -rf "$argv_dir"; [ -n "$open_dir" ] && rm -rf "$open_dir"; [ -n "$elves_tmp" ] && rm -rf "$elves_tmp"; [ -n "$update_dir" ] && rm -rf "$update_dir"; [ -n "$model_dir" ] && rm -rf "$model_dir"' EXIT
 
 printf '%s\n' 'HELPER_AGENT="devin"' 'HELPER_SPAWN_KIND="claude"' >"$tmp"
 HELPER_AGENT=""
@@ -143,6 +144,8 @@ case $front_real in
 esac
 grep -q 'helper_force_front_path "$plugin_root/bin"' "$root/launch.sh" ||
     fail "launch.sh should force the wrapper to the front of PATH"
+grep -q 'helper_relay_agent_start' "$root/bin/herdr" ||
+    fail "bin/herdr should relay agent start for the Codex startup gate"
 rm -rf "$resolve_dir"
 
 # The plugin must never invoke bare `bash`. On Windows the bash on PATH is the
@@ -1033,6 +1036,211 @@ unset HERDR_REAL
 rm -rf "$fake_prompt"
 fake_prompt=
 
+# Codex first-run gates. Herdr returns agent_not_ready as soon as the
+# seat is blocked during startup. The wrapper reads that named pane and
+# sends only the key that gate wants.
+[ "$(helper_codex_startup_key "$(printf '%s\n' \
+    '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue')")" = Enter ] ||
+    fail "trust dialog should send Enter"
+[ "$(helper_codex_startup_key "$(printf '%s\n' \
+    'Do you trust the contents of this' \
+    'directory?')")" = Enter ] ||
+    fail "a wrapped trust question should still send Enter"
+[ "$(helper_codex_startup_key 'Start a new chat? [y/n]')" = y ] ||
+    fail "[y/n] new-chat confirm should send y"
+[ "$(helper_codex_startup_key 'Resume this session? yes (y)')" = y ] ||
+    fail "yes (y) new-chat confirm should send y"
+if helper_codex_startup_key 'Allow command?' >/dev/null; then
+    fail "a later permission prompt must not look like a first-run gate"
+fi
+if helper_codex_startup_key 'press enter to confirm or esc to cancel' >/dev/null; then
+    fail "a later confirm prompt must not look like a first-run gate"
+fi
+if helper_codex_startup_key 'codex is starting...' >/dev/null; then
+    fail "unrelated pane text must not look like a first-run gate"
+fi
+[ "$(helper_argv_option_value --kind agent start reviewer --kind codex --pane w1:p1)" = codex ] ||
+    fail "--kind value"
+[ "$(helper_argv_option_value --pane agent start reviewer --kind=codex --pane=w1:p1)" = w1:p1 ] ||
+    fail "--pane= value"
+if helper_argv_option_value --kind agent start reviewer --pane w1:p1 -- --kind codex >/dev/null; then
+    fail "a --kind after -- must not be read as the seat kind"
+fi
+
+fake_start=$(mktemp -d)
+cat >"$fake_start/herdr" <<'EOF'
+#!/bin/sh
+case "$1 $2" in
+"agent start")
+    if [ "${FAKE_START_OK:-}" = 1 ]; then
+        printf 'agent start %s\n' "$3"
+        exit 0
+    fi
+    if [ "${FAKE_START_ERR:-agent_not_ready}" != agent_not_ready ]; then
+        printf '{"error":{"code":"%s","message":"start failed: %s"}}\n' \
+            "$FAKE_START_ERR" "$3" >&2
+        exit 1
+    fi
+    printf '{"error":{"code":"agent_not_ready","message":"%s is blocked during startup and is not ready for prompts"}}\n' \
+        "$3" >&2
+    exit 1
+    ;;
+"agent get")
+    ready=false
+    [ -f "${FAKE_READY_FILE:-}" ] && ready=true
+    printf '{"result":{"agent":{"pane_id":"%s","interactive_ready":%s,"agent_status":"blocked"}}}\n' \
+        "${FAKE_AGENT_PANE:-w1:p1}" "$ready"
+    exit 0
+    ;;
+"agent read")
+    cat "$FAKE_PANE" 2>/dev/null
+    exit 0
+    ;;
+"agent send-keys")
+    printf 'agent send-keys %s %s\n' "$3" "$4"
+    [ -n "${FAKE_START_DEAF:-}" ] || : >"${FAKE_READY_FILE:-/dev/null}"
+    exit 0
+    ;;
+"agent wait")
+    printf '%s\n' "$*"
+    exit 0
+    ;;
+esac
+printf '%s\n' "$*"
+exit 0
+EOF
+chmod +x "$fake_start/herdr"
+export HERDR_REAL="$fake_start/herdr"
+export HERDR_HELPER_OK=1
+export FAKE_PANE="$fake_start/pane.txt"
+export FAKE_READY_FILE="$fake_start/ready"
+export FAKE_AGENT_PANE=w1:p1
+export FAKE_START_ERR=agent_not_ready
+unset FAKE_START_OK
+unset FAKE_START_DEAF
+: >"$FAKE_PANE"
+rm -f "$FAKE_READY_FILE"
+
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "Codex trust gate should recover after Enter"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "Codex trust gate did not send Enter to the named seat"
+printf '%s\n' "$out" | grep -q 'agent wait reviewer --until idle' ||
+    fail "Codex trust gate did not wait until idle"
+
+rm -f "$FAKE_READY_FILE"
+printf '%s\n' 'Start a new chat? [y/n]' >"$FAKE_PANE"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "Codex new-chat [y/n] should recover after y"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
+    fail "Codex new-chat confirm did not send y to the named seat"
+
+rm -f "$FAKE_READY_FILE"
+printf '%s\n' 'Resume this session? yes (y)' >"$FAKE_PANE"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>/dev/null) ||
+    fail "Codex yes (y) confirm should recover after y"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer y' ||
+    fail "Codex yes (y) confirm did not send y"
+
+# A successful start must not send keys.
+export FAKE_START_OK=1
+rm -f "$FAKE_READY_FILE"
+out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1) ||
+    fail "a successful Codex start should pass through"
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a successful start must not send keys"
+fi
+unset FAKE_START_OK
+
+# Claude on the same dialog is somebody else's seat.
+rm -f "$FAKE_READY_FILE"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a non-Codex blocked start must not be reported as seated"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a non-Codex start must not send keys into the pane"
+fi
+
+# Unrelated start failure, even with a trust dialog on screen.
+export FAKE_START_ERR=pane_not_found
+rm -f "$FAKE_READY_FILE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "an unrelated start failure must not be reported as seated"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "an unrelated start failure must not send keys"
+fi
+export FAKE_START_ERR=agent_not_ready
+
+# The named agent is sitting in another pane. Do not type into it.
+export FAKE_AGENT_PANE=w2:p9
+rm -f "$FAKE_READY_FILE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a pane mismatch must not be reported as seated"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a pane mismatch must not send keys into another agent's pane"
+fi
+export FAKE_AGENT_PANE=w1:p1
+
+# A later permission prompt during startup is not a first-run gate.
+rm -f "$FAKE_READY_FILE"
+printf '%s\n' 'Allow command?' 'press enter to confirm or esc to cancel' >"$FAKE_PANE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a later permission prompt must not be auto-dismissed"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a later permission prompt must not receive keys"
+fi
+
+# Kind taken from agent args after -- must not trigger the gate.
+rm -f "$FAKE_READY_FILE"
+printf '%s\n' 'Start a new chat? [y/n]' >"$FAKE_PANE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 -- --kind codex 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a --kind after -- must not trigger the Codex startup gate"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a --kind after -- must not send keys"
+fi
+
+# Enter that never makes the seat interactive_ready is a failed start.
+export FAKE_START_DEAF=1
+rm -f "$FAKE_READY_FILE"
+printf '%s\n' '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue' >"$FAKE_PANE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a gate that did not become ready must not be reported as seated"
+fi
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "the unreadied trust gate should still press Enter"
+grep -q 'did not become ready' "$err" ||
+    fail "an unreadied Codex seat should say why"
+unset FAKE_START_DEAF
+
+unset FAKE_PANE
+unset FAKE_READY_FILE
+unset FAKE_AGENT_PANE
+unset FAKE_START_ERR
+unset FAKE_START_OK
+unset HERDR_REAL
+rm -rf "$fake_start"
+fake_start=
+
 # Windows: bin/herdr has no file extension, so a native caller resolving
 # `herdr` on PATH skips it under PATHEXT and reaches the real herdr.exe. The
 # .cmd sibling is what that caller finds instead. Nothing here runs elsewhere.
@@ -1599,6 +1807,10 @@ grep -q 'helper_agent_takes_effort' "$root/launch.sh" ||
     fail "launch.sh effort flags should share the lib.sh membership"
 grep -qF 'This chat runs $chat_identity' "$root/launch.sh" ||
     fail "the launch.sh appendix should name what the chat runs"
+grep -qF 'agent_not_ready' "$root/prompt.md" ||
+    fail "prompt.md does not describe the Codex startup gate"
+grep -qF 'agent_not_ready' "$root/launch.sh" ||
+    fail "the launch.sh appendix does not describe the Codex startup gate"
 grep -q 'helper_cursor_default_model' "$root/launch.sh" ||
     fail "launch.sh should take the cursor default model from lib.sh"
 # And what is supposed to be happening where: after a confirmed seat, each


### PR DESCRIPTION
## Summary
- After a Codex `agent start` returns `agent_not_ready` / blocked during startup, the lantern wrapper reads that named pane and sends Enter for the directory trust dialog or `y` for a `[y/n]` / `yes (y)` new-chat confirm.
- If those gates appear in sequence, or a `[y/n]` still needs Enter after `y`, it keeps going on that same pane (up to three keys) and waits until idle and `interactive_ready`.
- Other start failures, other kinds, mismatched panes, and later permission prompts are left alone. Herdr itself is unchanged.

## Test plan
- [x] `sh tests/smoke.sh`
- [x] Stub coverage for trust, `[y/n]`, `yes (y)`, trust-then-new-chat, stuck `[y/n]` needing Enter, delayed paint, and the refusals (Claude, other errors, other panes, later permission prompts)
- [ ] Seat Codex in a directory that still shows the trust dialog and confirm `herdr agent start` returns 0
- [ ] Seat Codex when trust is followed by a new-chat `[y/n]` and confirm it continues
- [ ] Confirm a Claude (or other kind) blocked start does not receive keys
- [ ] Confirm a later Codex permission prompt is not auto-dismissed