### PR TITLE
Name every open tab in the field status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.9.5] - 2026-08-22
+
+### Changed
+
+- Light-up and "what's going on" now name every open Herdr tab, not only
+  NEEDS YOU and IN MOTION. The answer still leads with who needs the user,
+  then gives one line per tab: workspace label, tab label, kind, and state
+  (working, blocked, done, or idle). The lantern joins `herdr tab list`
+  with `herdr agent list` on `tab_id` and with `herdr workspace list` on
+  `workspace_id`, so the line carries the sidebar name (`elves-run`,
+  `chrome`, `lantern · 2`) rather than a repository name. Quiet and idle
+  tabs stay in the list. Two tabs in one workspace are two lines, both
+  named. A tab with no agent reads as `shell`. Nothing else is added per
+  tab, and answers stay short. Seating, gates, and the Elves rules are
+  unchanged.
+- The plugin version is 0.9.5.
+
 ## [0.9.4] - 2026-08-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.9.4** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.9.5** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.9.4 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.9.5 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.9.4"
+version = "0.9.5"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.4</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.5</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>

--- a/launch.sh
+++ b/launch.sh
@@ -179,6 +179,15 @@ Runtime (injected by launch.sh; do not ignore):
 - A yolo request does not select every bypass. Name the one
   provider-specific flag and the protections it removes in the gated seat
   plan. Run it only after the user confirms that exact plan.
+- Field status names every open tab. On light-up, and for "what’s going on"
+  or any field question, lead with who needs the user, then give one line per
+  open Herdr tab: workspace label, tab label, kind, state (working / blocked /
+  done / idle). Join \`herdr tab list\` with \`herdr agent list\` on
+  \`tab_id\` and with \`herdr workspace list\` on \`workspace_id\`. Use the
+  tab label exactly as the sidebar shows it (\`elves-run\`, \`chrome\`,
+  \`lantern · 2\`). Quiet and idle tabs stay in the list. Two tabs in one
+  workspace are two lines, both named. A tab with no agent is \`shell\`. Add
+  nothing else to those lines; keep the answer short.
 - Route loose phrases. "What’s going on" means field status and agent,
   workspace, and tab lists. "Open the tab" means an exact agent, workspace,
   or tab focus. Offer it with, "Would you like me to open the tab?" "Tell

--- a/prompt.md
+++ b/prompt.md
@@ -18,7 +18,7 @@ list` before you create anything. Reuse the workspace for the same cwd.
 
 | User language | Verified route | Rule |
 | --- | --- | --- |
-| "what's going on", "status", "show the field" | `herdr status`, `herdr agent list`, `herdr agent read/get/wait/explain`, `herdr workspace list`, `herdr tab list` | Read-only. Use the smallest query that answers the question. |
+| "what's going on", "status", "show the field" | `herdr status`, `herdr agent list`, `herdr agent read/get/wait/explain`, `herdr workspace list`, `herdr tab list` | Read-only. Lead with who needs the user, then name every open tab. See "Field status: name every tab". |
 | "open the tab", "walk me there", "open finances", "focus finances" | `herdr agent focus <target>`, `herdr workspace focus <workspace_id>`, or `herdr tab focus <tab_id>` | Ask, "Would you like me to open the tab?" Confirm the exact target. Then use the mutation gate. |
 | "open battle paddle with codex", "seat another" | `herdr workspace create --cwd <dir> --label <label> --no-focus`, `herdr agent start <slug> --kind <kind> --pane <pane_id> -- <kind args>`, optional `herdr agent prompt`, then `herdr tab rename` | Confirm the full seat plan. Do not create a second workspace for the same cwd. |
 | "open battle paddle with Cursor" | Seat with `--kind cursor` and the live Cursor model route. | "Cursor" selects the Cursor CLI. |
@@ -288,8 +288,6 @@ words name that task.
    - If `agent start` fails, wait two seconds and retry once.
 
 2. Illuminate the field.
-   - The sidebar already rolls up working / blocked / done / idle. Do not
-     pretend Herdr hid that. You add what they are aiming at.
    - `herdr agent list` is the herd in the field. Status is lifecycle, not
      progress.
      Titles are often the current job.
@@ -301,6 +299,27 @@ words name that task.
    - `herdr agent focus <target>` opens the tab for them. Ask, "Would you
      like me to open the tab?" Confirm, then
      `HERDR_HELPER_OK=1`.
+
+### Field status: name every tab
+
+On light-up, and for "what's going on" or any field question, lead with who
+needs the user. Then name every open Herdr tab. Not only NEEDS YOU and
+IN MOTION. A quiet tab still gets its line.
+
+- Read `herdr tab list` for the tabs, `herdr agent list` for the kind in
+  each one, and `herdr workspace list` for the workspace label. Join tabs
+  to agents on `tab_id` and to workspaces on `workspace_id`.
+- One line per tab, in this order: workspace label, tab label, kind, state.
+  State is the tab's `agent_status`: working, blocked, done, or idle
+  (unknown when Herdr says so).
+- Use the tab `label` exactly as the sidebar shows it, such as `elves-run`,
+  `chrome`, or `lantern · 2`. Do not shorten it, translate it, or replace it
+  with a repository name.
+- One line per `tab_id`. Two tabs in one workspace are two lines, both
+  named. Never fold them into a workspace count.
+- A tab with no agent has no kind. Say `shell`.
+- Add nothing else to these lines. Goals, recaps, and next actions belong
+  to the who-needs-you part above, not to this list.
 
 Ground rules:
 
@@ -373,6 +392,8 @@ Elves — say that once, briefly, not as a pitch, and in the same line
 name the CLI and model this chat runs (the runtime note carries them),
 so the user always knows what is answering. Lead with who needs the
 user (NEEDS YOU, then live goals waiting on them). If none, one line
-about the field. If `elves_detected 1`, add the IN PROGRESS count and
-names (or one line each if few). If `elves_detected 0`, at most one
-short pairing line. Ask what to do. Do not mention the snapshot files.
+about the field. Then name every open tab, one line each, by the rules
+in "Field status: name every tab". If `elves_detected 1`, add the
+IN PROGRESS count and names (or one line each if few). If
+`elves_detected 0`, at most one short pairing line. Ask what to do. Do
+not mention the snapshot files.

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1989,4 +1989,40 @@ grep -qF 'tab rename' "$root/prompt.md" ||
     fail "prompt.md should rename a seated agent's tab"
 printf 'ok: the chat and its seats say what they run\n'
 
+# Field status is the whole field. Light-up and "what's going on" used to
+# name only the panes that needed the user or were moving, so a quiet tab
+# was invisible in a chat that claims to light the field. Every instruction
+# surface must now name every open tab, and both prompt.md and the rendered
+# appendix carry the same rule, because a lantern seated on Cursor or Codex
+# reads the appendix copy and never the file in this repo.
+grep -qF 'Field status: name every tab' "$root/prompt.md" ||
+    fail "prompt.md has no field status section"
+for field_file in prompt.md launch.sh; do
+    for field_word in 'herdr tab list' 'herdr agent list' \
+        'herdr workspace list' 'workspace label' 'tab label'; do
+        grep -qF -- "$field_word" "$root/$field_file" ||
+            fail "$field_file field status does not name $field_word"
+    done
+    # The sidebar name is the point: elves-run, chrome, and a second lantern
+    # tab in the same workspace are what the user reads in Herdr, and a
+    # per-workspace roll-up would drop the second one.
+    for field_example in 'elves-run' 'chrome' 'lantern · 2'; do
+        grep -qF -- "$field_example" "$root/$field_file" ||
+            fail "$field_file field status does not keep the sidebar name $field_example"
+    done
+    grep -qF 'Two tabs in one' "$root/$field_file" ||
+        fail "$field_file does not name both tabs in one workspace"
+    grep -qiE 'quiet and idle tabs stay|a quiet tab still gets its line' \
+        "$root/$field_file" ||
+        fail "$field_file drops quiet tabs from the field status"
+done
+# Who needs the user still comes first, and the answer stays a lamp.
+grep -qF 'lead with who needs the user' "$root/launch.sh" ||
+    fail "the launch.sh appendix should still lead with who needs the user"
+grep -qF 'Then name every open tab' "$root/prompt.md" ||
+    fail "the prompt.md light-up should name every open tab after who needs you"
+grep -qF 'Keep answers short' "$root/prompt.md" ||
+    fail "prompt.md should still keep answers short"
+printf 'ok: field status names every open tab\n'
+
 printf 'ok\n'


### PR DESCRIPTION
## What

Light-up and "what's going on" named only NEEDS YOU and IN MOTION, so a quiet tab was invisible in a chat whose job is to light the field.

The answer still leads with who needs the user. After that it gives one line per open Herdr tab: workspace label, tab label, kind, and state (working / blocked / done / idle).

## How

- `prompt.md` gets a "Field status: name every tab" section. It names the joins: `herdr tab list` to `herdr agent list` on `tab_id`, and to `herdr workspace list` on `workspace_id` for the workspace label.
- The tab label stays exactly as the sidebar shows it (`elves-run`, `chrome`, `lantern · 2`), never a repository name.
- One line per `tab_id`, so two lantern tabs in one workspace are both named. Quiet and idle tabs stay in the list. A tab with no agent reads as `shell`.
- Nothing else is added per tab. Goals, recaps, and next actions stay in the who-needs-you part above.
- The routing table row for "what's going on" and the light-up paragraph both point at the new section. The old line that told the lantern not to repeat the sidebar roll-up is removed, because it blocked this.
- The same rule is in the `launch.sh` appendix, so the copies launch writes (AGENTS.md, CLAUDE.md, `.windsurf/rules/lantern.md`, `.cursor/rules/lantern.mdc`) all carry it. All four rendered files were checked.

Seating, gates, and the Elves rules are unchanged. `bin/goals-floor` is unchanged.

## Tests

New `tests/smoke.sh` block "field status names every open tab". It checks both `prompt.md` and `launch.sh` for the three list commands, the workspace and tab label fields, the three sidebar examples, the two-tabs-in-one-workspace rule, and the quiet-tab rule. It also checks that light-up still leads with who needs the user and that "Keep answers short" survives.

Full suite passes.

## Release

Version 0.9.5 in `herdr-plugin.toml`, `README.md`, `howto.html`, `docs/index.html`, and `CHANGELOG.md`.