### PR TITLE
Default GitHub repos Lantern creates to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.9.7] - 2026-08-23
+
+### Changed
+
+- GitHub repositories Lantern creates are private by default. The routing
+  table and helper instructions require `gh repo create --private`. Public
+  only when the user explicitly asks for a public repo.
+- The plugin version is 0.9.7.
+
 ## [0.9.6] - 2026-08-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.9.6** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.9.7** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 
@@ -133,6 +133,10 @@ the model before it creates a workspace or tab. It reuses a matching Codex,
 Cursor, Cursor Grok, or Grok Build agent. Otherwise it seats the requested
 kind with its real review or read-only plan command. Lantern never checks out
 the pull request or edits the product repository.
+
+GitHub repositories Lantern creates are private. `gh repo create` always
+includes `--private`. It does not pass `--public` unless you explicitly ask
+for a public repo.
 
 After a confirmed seat the lantern renames the agent's tab to
 `<slug> · <kind>` and says in one line what is running where: the slug, the

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.9.6 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.9.7 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>
@@ -389,6 +389,7 @@ No Elves install required. If there are no
         <li>“Open the image maker repo with claude.”<span>Reuse if they are already there. Slugs: <code>image-maker</code>, not “Image Maker”.</span></li>
         <li>“There is a PR on battle-paddle. Get a Codex review.”<span>Resolve the repository and PR first. Check the model before any workspace or tab change. Lantern does not edit the repository.</span></li>
         <li>“Open battle paddle with Grok.”<span>Bare Grok means Cursor with a live Cursor Grok model. Say Grok Build to use the Grok CLI.</span></li>
+        <li>“Create a GitHub repo for X.”<span>Always <code>gh repo create --private</code>. Public only when you ask for public.</span></li>
         <li>“Make a worktree on herdr for branch helper-tests.”<span><code>herdr worktree create</code>, not a second workspace on the main checkout.</span></li>
         <li>“How’s the night shift?”<span>If Elves session files are around, it reads that floor. It does not cobble or land.</span></li>
       </ul>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.9.6"
+version = "0.9.7"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.6</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.7</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>
@@ -333,6 +333,10 @@ HELPER_EXTRA_ARGS=""</pre>
       <li>
         “Open battle paddle with Grok.”
         <span>Bare Grok means Cursor with a live Cursor Grok model. Say Grok Build to use the Grok CLI.</span>
+      </li>
+      <li>
+        “Create a GitHub repo for X.”
+        <span>Always <code>gh repo create --private</code>. Public only when you ask for public.</span>
       </li>
       <li>
         “Make a worktree on herdr for branch helper-tests.”

--- a/launch.sh
+++ b/launch.sh
@@ -201,7 +201,9 @@ Runtime (injected by launch.sh; do not ignore):
   or tab focus. Offer it with, "Would you like me to open the tab?" "Tell
   them X" means an exact gated agent prompt. "Open battle
   paddle with Codex" means resolve the repo, reuse its workspace, and seat
-  Codex. "Second tab same way" means create a tab in that same workspace and
+  Codex. "Create a GitHub repo" means \`gh repo create <name> --private\`.
+  Never \`--public\` unless the user explicitly asks for a public repository.
+  "Second tab same way" means create a tab in that same workspace and
   reuse the last verified kind and model settings. Resume uses the real kind
   CLI: Codex \`--dangerously-bypass-approvals-and-sandbox resume --last\`, Claude \`--continue\`, OMP \`--continue\` or
   \`-r <id>\`, Cursor \`--continue\` or \`--resume <id>\`, Grok
@@ -249,7 +251,9 @@ Runtime (injected by launch.sh; do not ignore):
 - Close a workspace, tab, pane, or worktree only when the user names it.
   Split, zoom, or swap panes only when asked. Plugin and integration installs
   are gated. Never merge, run land-pr, edit product repositories, or close the
-  Lantern home tab, pane, or workspace.
+  Lantern home tab, pane, or workspace. GitHub repositories Lantern creates
+  are private: \`gh repo create\` must include \`--private\`. Do not pass
+  \`--public\` unless the user explicitly asks for a public repository.
 - update.txt in this workdir is this light-up’s version check. If it says a
   newer version is published, offer the update once, in one line; if it says
   up to date or unavailable, say nothing about it. There is no

--- a/prompt.md
+++ b/prompt.md
@@ -38,11 +38,14 @@ list` before you create anything. Reuse the workspace for the same cwd.
 | "split right/down", "zoom this", "swap panes" | `herdr pane split`, `herdr pane zoom`, or `herdr pane swap` with the verified target and direction flags | Run only when asked. Confirm the exact pane operation. |
 | "list/install plugins", "update Lantern" | `herdr plugin list` or `herdr plugin install <owner/repo>` | List is read-only. Install is gated. Reinstall Lantern only after confirmation. |
 | "integration status/install" | `herdr integration status` or `herdr integration install <target>` | Status is read-only. Install is gated. |
+| "create a GitHub repo", "put this on GitHub", "make a repo" | `gh repo create <name> --private` | Always pass `--private`. Never `--public` unless the user explicitly asks for a public repo. |
 
 Never merge, run `land-pr`, edit a product repository, or close the Lantern
 home tab, pane, or workspace. Observing a repository and routing a task to a
 seated agent is allowed. Lantern itself does not check out a pull request or
-apply a diff in a product repository.
+apply a diff in a product repository. GitHub repositories Lantern creates
+are private: `gh repo create` must include `--private`. Do not pass
+`--public` unless the user explicitly asks for a public repository.
 
 ### Named pull request review
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -501,6 +501,16 @@ grep -qF '"Grok Build" and' "$root/launch.sh" ||
     fail "launch.sh does not route Grok Build to the Grok CLI"
 grep -qF 'Never merge' "$root/prompt.md" ||
     fail "prompt.md does not forbid merge from Lantern"
+for repo_file in prompt.md launch.sh README.md; do
+    grep -qF 'gh repo create' "$root/$repo_file" ||
+        fail "$repo_file does not route GitHub repo creation"
+    grep -qF -- '--private' "$root/$repo_file" ||
+        fail "$repo_file does not require private GitHub repos"
+    grep -qF -- '--public' "$root/$repo_file" ||
+        fail "$repo_file does not forbid public GitHub repos unless asked"
+done
+grep -qF '"create a GitHub repo"' "$root/prompt.md" ||
+    fail "prompt.md has no GitHub repo creation route"
 grep -qF 'Finish this step before any' "$root/prompt.md" ||
     fail "named PR route does not preflight before herd mutation"
 grep -qF 'confirms the exact flag and the protections it removes' "$root/README.md" ||


### PR DESCRIPTION
## Summary

- GitHub repositories Lantern creates are private by default. The routing table and helper instructions require `gh repo create --private`.
- `--public` is only allowed when the user explicitly asks for a public repo.
- Version 0.9.7 in the plugin manifest, README, pages, and changelog.

## Test plan

- [x] `sh tests/smoke.sh` (local)
- [ ] GitHub smoke jobs on Linux, macOS, and Windows
- [ ] After merge: tag/release `v0.9.7`, then `herdr plugin install aigorahub/herdr-lantern` on a GitHub install and reopen the lantern chat