### PR TITLE
Dismiss Claude's first-run folder trust screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.9.8] - 2026-08-23
+
+### Fixed
+
+- Claude seats that stop on the first-run folder trust screen (Accessing
+  workspace, `Yes, I trust this folder`, Enter to confirm) no longer die as
+  `agent_not_ready`. The herdr wrapper reads that named start pane, sends one
+  Enter, and waits until the seat is idle or done and `interactive_ready`.
+  Only that screen counts: later permission prompts, a Codex directory-trust
+  dialog, a new-chat `[y/n]`, another agent in that pane, another pane, and
+  every other start failure are unchanged. The Codex gate is unchanged.
+- The plugin version is 0.9.8.
+
 ## [0.9.7] - 2026-08-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.9.7** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.9.8** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.9.7 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.9.8 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.9.7"
+version = "0.9.8"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.7</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.8</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>

--- a/launch.sh
+++ b/launch.sh
@@ -143,13 +143,14 @@ Runtime (injected by launch.sh; do not ignore):
   (Cursor often types into the follow-up field without submitting), and
   it fails when nothing shows the message went in. Read the pane before
   saying sent.
-- \`herdr agent start\` through the wrapper, for Codex only, dismisses the
-  first-run directory trust dialog with Enter or a new-chat \`[y/n]\` /
-  \`yes (y)\` confirm with y when Herdr returns \`agent_not_ready\` /
-  blocked during startup on that named pane. If both appear, it dismisses
-  them in order. It waits until idle or done and
-  \`interactive_ready\`. It does not send keys into any other failure,
-  another agent’s pane, or later permission prompts.
+- \`herdr agent start\` through the wrapper dismisses first-run gates when
+  Herdr returns \`agent_not_ready\` / blocked during startup on that named
+  pane. For Codex: the directory trust dialog with Enter, or a new-chat
+  \`[y/n]\` / \`yes (y)\` confirm with y. If both appear, it dismisses them
+  in order. For Claude: the folder trust screen (Accessing workspace,
+  \`Yes, I trust this folder\`) with one Enter, and nothing else. It waits
+  until idle or done and \`interactive_ready\`. It does not send keys into
+  any other failure, another agent’s pane, or later permission prompts.
 - This chat runs $chat_identity. Name that in your light-up line — it is
   how the user tells which CLI and model is answering — and repeat it
   whenever they ask.

--- a/lib.sh
+++ b/lib.sh
@@ -599,8 +599,9 @@ helper_codex_startup_key() {
     return 1
 }
 
-helper_codex_is_ready() {
-    # True when agent get JSON ($1) says the seat can take prompts.
+helper_seat_is_ready() {
+    # True when agent get JSON ($1) says the seat can take prompts. Both
+    # kinds report the same fields, so one check serves both.
     # Unfocused new seats report done rather than idle, so both count.
     case $1 in
     *"\"interactive_ready\":true"*) ;;
@@ -662,7 +663,7 @@ helper_claude_startup_gate() {
     _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
         _helper_got=
     if helper_seat_ok "$_helper_got" "$_helper_pane" claude &&
-        helper_codex_is_ready "$_helper_got"; then
+        helper_seat_is_ready "$_helper_got"; then
         return 0
     fi
     printf '%s\n' "lantern: Claude in $_helper_name did not become ready after the folder trust gate" >&2
@@ -801,7 +802,7 @@ helper_relay_agent_start() {
                 [ "$_helper_sent" -gt 0 ] && break
                 return $_helper_status
             }
-            helper_codex_is_ready "$_helper_got" && return 0
+            helper_seat_is_ready "$_helper_got" && return 0
             if [ "$_helper_sent" -gt 0 ]; then
                 _helper_post_miss=$((_helper_post_miss + 1))
                 [ "$_helper_post_miss" -ge 3 ] && break
@@ -835,7 +836,7 @@ helper_relay_agent_start() {
             _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
                 _helper_got=
             helper_codex_seat_ok "$_helper_got" "$_helper_pane" || return 1
-            helper_codex_is_ready "$_helper_got" && return 0
+            helper_seat_is_ready "$_helper_got" && return 0
         fi
     done
     [ "$_helper_sent" -gt 0 ] || return $_helper_status
@@ -847,7 +848,7 @@ helper_relay_agent_start() {
         return 1
     }
     helper_codex_seat_ok "$_helper_got" "$_helper_pane" || return 1
-    helper_codex_is_ready "$_helper_got" && return 0
+    helper_seat_is_ready "$_helper_got" && return 0
     printf '%s\n' "lantern: Codex in $_helper_name did not become ready after the startup gate" >&2
     return 1
 }

--- a/lib.sh
+++ b/lib.sh
@@ -551,6 +551,22 @@ helper_codex_pane_has_trust() {
     return 1
 }
 
+helper_claude_pane_has_trust() {
+    # True when pane text ($1) is Claude's first-run folder trust screen:
+    # Accessing workspace, Yes, I trust this folder, Enter to confirm.
+    # Later permission prompts are not a match, and neither is the Codex
+    # directory-trust dialog, which is a different screen on a different
+    # kind of seat.
+    helper_codex_pane_is_later_prompt "$1" && return 1
+    _helper_flat=$(helper_codex_flat_pane "$1")
+    case $_helper_flat in
+    *"trust this folder"*)
+        return 0
+        ;;
+    esac
+    return 1
+}
+
 helper_codex_pane_has_yn() {
     helper_codex_pane_is_later_prompt "$1" && return 1
     _helper_flat=$(helper_codex_flat_pane "$1")
@@ -598,23 +614,70 @@ helper_codex_is_ready() {
     return 1
 }
 
-helper_codex_seat_ok() {
-    # True when agent get JSON ($1) is still the Codex seat in pane ($2).
+helper_seat_ok() {
+    # True when agent get JSON ($1) is still kind ($3) in pane ($2).
     _helper_got_pane=$(printf '%s' "$1" | helper_json_value pane_id)
     [ "$_helper_got_pane" = "$2" ] || return 1
     _helper_got_agent=$(printf '%s' "$1" | helper_json_value agent)
-    [ "$_helper_got_agent" = codex ] || return 1
+    [ "$_helper_got_agent" = "$3" ] || return 1
     return 0
 }
 
+helper_codex_seat_ok() {
+    # True when agent get JSON ($1) is still the Codex seat in pane ($2).
+    helper_seat_ok "$1" "$2" codex
+}
+
+helper_claude_startup_gate() {
+    # Claude first-run folder trust. Only that screen, only the named
+    # start pane, and only one Enter. $1 real herdr, $2 name, $3 pane,
+    # $4 the start status to return when this is not that gate.
+    _helper_real=$1
+    _helper_name=$2
+    _helper_pane=$3
+    _helper_status=$4
+    _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
+        return "$_helper_status"
+    helper_seat_ok "$_helper_got" "$_helper_pane" claude ||
+        return "$_helper_status"
+    _helper_miss=0
+    while :; do
+        _helper_before=$("$_helper_real" agent read "$_helper_name" --lines 60 2>/dev/null) ||
+            _helper_before=
+        helper_claude_pane_has_trust "$_helper_before" && break
+        _helper_miss=$((_helper_miss + 1))
+        [ "$_helper_miss" -ge 2 ] && return "$_helper_status"
+        # Herdr already called it blocked; the dialog may still be
+        # painting. --until idle times out while it stays blocked.
+        "$_helper_real" agent wait "$_helper_name" --until idle --until done \
+            --timeout 2000 >/dev/null 2>&1 || true
+    done
+    _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
+        return "$_helper_status"
+    helper_seat_ok "$_helper_got" "$_helper_pane" claude ||
+        return "$_helper_status"
+    "$_helper_real" agent send-keys "$_helper_name" Enter || return $?
+    "$_helper_real" agent wait "$_helper_name" --until idle --until done \
+        --timeout 120000 || return $?
+    _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
+        _helper_got=
+    if helper_seat_ok "$_helper_got" "$_helper_pane" claude &&
+        helper_codex_is_ready "$_helper_got"; then
+        return 0
+    fi
+    printf '%s\n' "lantern: Claude in $_helper_name did not become ready after the folder trust gate" >&2
+    return 1
+}
+
 helper_relay_agent_start() {
-    # Codex first-run survival. Herdr returns agent_not_ready as soon as
-    # detection reports blocked during startup, so a directory-trust or
-    # new-chat confirm kills the seat. Trust and a new-chat confirm can
-    # appear in sequence, and a [y/n] prompt may still need Enter after
-    # y. This stays on that same named pane and sends only those keys.
-    # Any other failure, another kind, or another agent's pane is left
-    # alone.
+    # Codex and Claude first-run survival. Herdr returns agent_not_ready
+    # as soon as detection reports blocked during startup, so a
+    # first-run gate kills the seat. For Codex, trust and a new-chat
+    # confirm can appear in sequence, and a [y/n] prompt may still need
+    # Enter after y. For Claude, the only gate handled is the folder
+    # trust screen, and the only key is one Enter. This stays on that
+    # same named pane and sends only those keys. Any other failure,
+    # another kind, or another agent's pane is left alone.
     _helper_real=$1
     shift
     _helper_name=$3
@@ -685,12 +748,20 @@ helper_relay_agent_start() {
     cat "$_helper_errf" >&2
     rm -f "$_helper_errf"
     [ "$_helper_status" -eq 0 ] && return 0
-    [ "$_helper_kind" = codex ] || return $_helper_status
+    case $_helper_kind in
+    codex | claude) ;;
+    *) return $_helper_status ;;
+    esac
     [ -n "$_helper_name" ] && [ -n "$_helper_pane" ] || return $_helper_status
     case $_helper_err in
     *agent_not_ready* | *"blocked during startup"*) ;;
     *) return $_helper_status ;;
     esac
+    if [ "$_helper_kind" = claude ]; then
+        helper_claude_startup_gate "$_helper_real" "$_helper_name" \
+            "$_helper_pane" "$_helper_status"
+        return $?
+    fi
     _helper_got=$("$_helper_real" agent get "$_helper_name" 2>/dev/null) ||
         return $_helper_status
     helper_codex_seat_ok "$_helper_got" "$_helper_pane" || return $_helper_status

--- a/prompt.md
+++ b/prompt.md
@@ -238,11 +238,13 @@ words name that task.
      the input field (common on Cursor), sends Enter and waits again. It
      fails rather than guess when nothing shows the message went in.
      Read the pane before telling the user it was sent.
-     For Codex, `agent start` through the wrapper dismisses the first-run
-     directory trust dialog with Enter, or a new-chat `[y/n]` / `yes (y)`
-     confirm with y, only when Herdr returns `agent_not_ready` / blocked
-     during startup on that same named pane. If both appear, it dismisses
-     them in order. It then waits until idle or done and
+     `agent start` through the wrapper dismisses first-run gates, only
+     when Herdr returns `agent_not_ready` / blocked during startup on that
+     same named pane. For Codex: the directory trust dialog with Enter, or
+     a new-chat `[y/n]` / `yes (y)` confirm with y. If both appear, it
+     dismisses them in order. For Claude: the folder trust screen
+     (Accessing workspace, `Yes, I trust this folder`, Enter to confirm)
+     with one Enter, and nothing else. It then waits until idle or done and
      `interactive_ready`. It does not send keys into any other failure,
      another agent's pane, or later permission prompts. Do not send y or
      Enter yourself for those startup gates.

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1088,6 +1088,45 @@ if helper_codex_seat_ok '{"agent":"claude","pane_id":"w1:p1"}' w1:p1; then
 fi
 helper_codex_seat_ok '{"agent":"codex","pane_id":"w1:p1"}' w1:p1 ||
     fail "a Codex occupant in the start pane should count"
+helper_seat_ok '{"agent":"claude","pane_id":"w1:p1"}' w1:p1 claude ||
+    fail "a Claude occupant in the start pane should count"
+if helper_seat_ok '{"agent":"codex","pane_id":"w1:p1"}' w1:p1 claude; then
+    fail "a Codex occupant must not count as the Claude seat"
+fi
+if helper_seat_ok '{"agent":"claude","pane_id":"w2:p9"}' w1:p1 claude; then
+    fail "a Claude seat in another pane must not count"
+fi
+
+# Claude first-run folder trust. One screen, one Enter, nothing else.
+helper_claude_pane_has_trust "$(printf '%s\n' \
+    'Accessing workspace' \
+    '/tmp/demo' \
+    '› 1. Yes, I trust this folder' \
+    '  2. No, choose another folder' \
+    'Enter to confirm')" ||
+    fail "the Claude folder trust screen should be a gate"
+helper_claude_pane_has_trust "$(printf '%s\n' \
+    'Yes, I' \
+    'trust this folder')" ||
+    fail "a wrapped Claude trust option should still be a gate"
+if helper_claude_pane_has_trust "$(printf '%s\n' \
+    '> You are in /tmp/demo' \
+    'Do you trust the contents of this directory?' \
+    '› 1. Yes, continue')"; then
+    fail "the Codex trust dialog must not be the Claude gate"
+fi
+if helper_claude_pane_has_trust 'press enter to confirm or esc to cancel'; then
+    fail "a later permission prompt must not look like the Claude gate"
+fi
+if helper_claude_pane_has_trust 'Do you want to make this edit to lib.sh?'; then
+    fail "a later edit permission prompt must not look like the Claude gate"
+fi
+if helper_claude_pane_has_trust 'Start a new chat? [y/n]'; then
+    fail "a new-chat confirm must not look like the Claude gate"
+fi
+if helper_claude_pane_has_trust 'claude is starting...'; then
+    fail "unrelated pane text must not look like the Claude gate"
+fi
 if helper_codex_startup_key 'press enter to confirm or esc to cancel' >/dev/null; then
     fail "a later confirm prompt must not look like a first-run gate"
 fi
@@ -1400,17 +1439,17 @@ check_start_log "$codex_start_head
     "a Codex review must get the unattended flag before the subcommand"
 unset FAKE_START_OK
 
-# Claude on the same dialog is somebody else's seat.
+# The Codex dialog on a Claude seat is somebody else's gate.
 rm -f "$FAKE_READY_FILE"
 printf '%s\n' '> You are in /tmp/demo' \
     'Do you trust the contents of this directory?' \
     '› 1. Yes, continue' >"$FAKE_PANE"
 if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>"$err"); then
     printf '%s\n' "$out" >&2
-    fail "a non-Codex blocked start must not be reported as seated"
+    fail "a Claude start on the Codex dialog must not be reported as seated"
 fi
 if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
-    fail "a non-Codex start must not send keys into the pane"
+    fail "a Claude start on the Codex dialog must not send keys into the pane"
 fi
 
 # Unrelated start failure, even with a trust dialog on screen.
@@ -1474,6 +1513,114 @@ printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
 grep -q 'did not become ready' "$err" ||
     fail "an unreadied Codex seat should say why"
 unset FAKE_START_DEAF
+
+# Claude first-run folder trust, same shape as Codex: only that screen,
+# only the named start pane, one Enter, then wait for a ready seat.
+claude_trust_pane() {
+    printf '%s\n' 'Accessing workspace' \
+        '/tmp/demo' \
+        '› 1. Yes, I trust this folder' \
+        '  2. No, choose another folder' \
+        'Enter to confirm' >"$FAKE_PANE"
+}
+export FAKE_GET_AGENT=claude
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+claude_trust_pane
+out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>/dev/null) ||
+    fail "Claude folder trust gate should recover after Enter"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "Claude folder trust gate did not send Enter to the named seat"
+printf '%s\n' "$out" | grep -q 'agent wait reviewer --until idle' ||
+    fail "Claude folder trust gate did not wait until idle"
+[ "$(printf '%s\n' "$out" | grep -c 'agent send-keys')" -eq 1 ] ||
+    fail "Claude folder trust gate should send exactly one key"
+
+# The dialog may still be painting when Herdr first reports blocked.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+printf '%s\n' 'claude is starting...' >"$FAKE_PANE_DELAY"
+claude_trust_pane
+out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>/dev/null) ||
+    fail "a delayed Claude trust screen should still recover"
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "a delayed Claude trust screen did not send Enter"
+rm -f "$FAKE_PANE_DELAY"
+
+# A later Claude permission prompt during startup is not a first-run gate.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+printf '%s\n' 'Allow command?' 'press enter to confirm or esc to cancel' >"$FAKE_PANE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a later Claude permission prompt must not be auto-dismissed"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a later Claude permission prompt must not receive keys"
+fi
+
+# A new-chat confirm is a Codex gate. Claude seats leave it alone.
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+printf '%s\n' 'Start a new chat? [y/n]' >"$FAKE_PANE"
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a [y/n] on a Claude seat must not be reported as seated"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a Claude seat must not answer a new-chat confirm"
+fi
+
+# A Codex occupant on the Claude trust screen is another agent's pane.
+export FAKE_GET_AGENT=codex
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+claude_trust_pane
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a Codex occupant must not be reported as a Claude seat"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a Codex occupant must not receive Claude startup keys"
+fi
+export FAKE_GET_AGENT=claude
+
+# The named agent is sitting in another pane. Do not type into it.
+export FAKE_AGENT_PANE=w2:p9
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+claude_trust_pane
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a Claude pane mismatch must not be reported as seated"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a Claude pane mismatch must not send keys into another agent's pane"
+fi
+export FAKE_AGENT_PANE=w1:p1
+
+# Unrelated start failure, even with the folder trust screen on show.
+export FAKE_START_ERR=pane_not_found
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+claude_trust_pane
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "an unrelated Claude start failure must not be reported as seated"
+fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "an unrelated Claude start failure must not send keys"
+fi
+export FAKE_START_ERR=agent_not_ready
+
+# Enter that never makes the seat interactive_ready is a failed start.
+export FAKE_START_DEAF=1
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
+claude_trust_pane
+if out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1 2>"$err"); then
+    printf '%s\n' "$out" >&2
+    fail "a Claude gate that did not become ready must not be reported as seated"
+fi
+printf '%s\n' "$out" | grep -q 'agent send-keys reviewer Enter' ||
+    fail "the unreadied Claude trust gate should still press Enter"
+grep -q 'did not become ready' "$err" ||
+    fail "an unreadied Claude seat should say why"
+unset FAKE_START_DEAF
+export FAKE_GET_AGENT=codex
+rm -f "$FAKE_READY_FILE" "$FAKE_READ_N"
 
 unset FAKE_PANE
 unset FAKE_PANE_NEXT

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1402,6 +1402,9 @@ out=$(sh "$root/bin/herdr" agent start reviewer --kind claude --pane w1:p1) ||
 if grep -qF -- '--dangerously-bypass-approvals-and-sandbox' "$FAKE_START_LOG"; then
     fail "a Claude start must not receive the Codex unattended flag"
 fi
+if printf '%s\n' "$out" | grep -q 'agent send-keys'; then
+    fail "a successful Claude start must not send keys"
+fi
 rm -f "$FAKE_START_LOG"
 out=$(sh "$root/bin/herdr" agent start reviewer --kind codex --pane w1:p1 \
     -- resume --last) ||

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1076,11 +1076,11 @@ fi
 if helper_codex_startup_key 'Approve MCP server startup? yes (y)' >/dev/null; then
     fail "a permission yes (y) must not look like a new-chat confirm"
 fi
-helper_codex_is_ready '{"interactive_ready":true,"agent_status":"idle"}' ||
+helper_seat_is_ready '{"interactive_ready":true,"agent_status":"idle"}' ||
     fail "idle plus interactive_ready should be ready"
-helper_codex_is_ready '{"interactive_ready":true,"agent_status":"done"}' ||
+helper_seat_is_ready '{"interactive_ready":true,"agent_status":"done"}' ||
     fail "done plus interactive_ready should be ready"
-if helper_codex_is_ready '{"interactive_ready":true,"agent_status":"blocked"}'; then
+if helper_seat_is_ready '{"interactive_ready":true,"agent_status":"blocked"}'; then
     fail "blocked plus interactive_ready must not count as seated"
 fi
 if helper_codex_seat_ok '{"agent":"claude","pane_id":"w1:p1"}' w1:p1; then


### PR DESCRIPTION
## What

`herdr agent start` through the Lantern wrapper already dismissed Codex first-run gates. A Claude seat that stopped on the folder trust screen (`Accessing workspace` / `Yes, I trust this folder` / `Enter to confirm`) still died as `agent_not_ready`.

The wrapper now handles that one screen for Claude: read the named start pane, send one Enter, then wait until the seat is idle or done and `interactive_ready`.

## Scope

Handled: the startup folder trust screen, on the named start pane, with a Claude occupant, after `agent_not_ready` / blocked during startup.

Not handled, and no keys sent: later permission prompts, the Codex directory trust dialog on a Claude seat, a new-chat `[y/n]`, a Codex occupant in that pane, the agent sitting in another pane, and any other start failure. The Codex path is unchanged.

## Changes

- `lib.sh`: `helper_claude_pane_has_trust`, `helper_claude_startup_gate`, and a generic `helper_seat_ok` that `helper_codex_seat_ok` now calls. `helper_relay_agent_start` accepts `--kind claude` and branches to the Claude gate.
- `tests/smoke.sh`: matcher unit tests and integration tests next to the Codex trust-gate smoke tests, covering recovery, delayed paint, one key only, and every case that must stay untouched.
- Docs: `prompt.md`, the `launch.sh` appendix, `CHANGELOG.md`. Version 0.9.8.

## Tests

`sh tests/smoke.sh` passes. Both new paths were verified to fail when the feature is removed.