### PR TITLE
Unclear is the only reason to ask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Lantern, by Elves are documented here.
 
+## [0.9.10] - 2026-08-23
+
+### Changed
+
+- Unclear is the only reason to ask. 0.9.9 kept a second reason the rule was
+  never meant to have: the action being destructive. A named, resolved
+  "close finances" is a clear request, and it stopped for a question anyway.
+  Closing a workspace, tab, or pane, `agent kill`, `worktree remove`, and a
+  plugin install now run like every other named request.
+- What still asks: the target does not resolve to exactly one thing, or was
+  never named ("clean up", "close that one"), or a model, repository, or
+  saved session does not resolve. That is the whole list.
+- Unchanged: the lantern never closes its own home tab, never acts on a
+  target the user did not name, and never upgrades the plugin on its own.
+  The `HERDR_HELPER_OK=1` gate in `bin/herdr` is unchanged.
+- The plugin version is 0.9.10.
+
 ## [0.9.9] - 2026-08-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Lantern, illuminating your herd](assets/lantern-banner.jpeg)
 
-**v0.9.9** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
+**v0.9.10** is a [Herdr](https://herdr.dev) plugin (`aigora.lantern`).
 
 From the team that brought you [Elves](https://github.com/aigorahub/elves).
 
@@ -105,10 +105,10 @@ shift?” It does not cobble or land.
 
 Mutating `herdr` commands (create, start, focus, close, …) go through
 `bin/herdr`, which reruns them with `HERDR_HELPER_OK=1`. Ask for
-something and the lantern does it. It stops to ask only when the target
-is unclear ("clean up", two repos with that name) or when the action
-destroys work you cannot get back: closing a workspace, tab, or pane,
-killing an agent, removing a worktree, or reinstalling the plugin.
+something and the lantern does it, then tells you what it did. It stops
+to ask only when the ask itself is unclear: no target named ("clean
+up"), or a name that matches two repositories. Closing, killing, and
+removing are not exceptions. It never closes the lantern's own tab.
 
 Agents the lantern seats for you start without stopping for ordinary
 approvals. `agent start` passes each kind's own flags after `--`: Claude

--- a/bin/herdr
+++ b/bin/herdr
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Inspect-by-default Herdr wrapper for Lantern.
-# Mutating verbs need HERDR_HELPER_OK=1 after the user confirms.
+# Mutating verbs need HERDR_HELPER_OK=1 in front of the same command.
 set -u
 
 self_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)

--- a/bin/herdr
+++ b/bin/herdr
@@ -35,7 +35,7 @@ esac
 
 printf 'lantern: blocked mutating herdr command:\n' >&2
 printf '  herdr %s\n' "$*" >&2
-printf 'Rerun with the prefix; ask the user first only when the target is\n' >&2
-printf 'unclear or the action destroys work:\n' >&2
+printf 'Rerun with the prefix; ask the user first only when the target\n' >&2
+printf 'is unclear:\n' >&2
 printf '  HERDR_HELPER_OK=1 herdr %s\n' "$*" >&2
 exit 2

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
       <img src="assets/lantern-banner.jpeg" width="1280" height="720" alt="The cobbler on a ridge at night, lantern in hand, looking down on his herd">
       <div class="hero-copy">
         <div class="wrap">
-          <p class="kicker">aigora.lantern · v0.9.9 · herdr 0.7.5+</p>
+          <p class="kicker">aigora.lantern · v0.9.10 · herdr 0.7.5+</p>
           <h1>Lantern, illuminating your herd</h1>
           <p class="lede">Herdr manages the herd. The herd is in the field. Lantern lights who needs you, what they are working toward, and how to get there. You talk. It runs <code>herdr</code>.</p>
         </div>
@@ -440,7 +440,7 @@ HELPER_EXTRA_ARGS=""</pre>
       <p class="note">Empty <code>HELPER_AGENT</code> picks the first of those CLIs on <code>PATH</code>. Conf is <code>KEY=value</code> only; it is never sourced. After an upgrade, copy repo <code>prompt.md</code> over the seeded file if you want the latest rules.</p>
 
       <h2>Trust</h2>
-      <p>Runs as you, with your environment. Read <code>launch.sh</code>, <code>lib.sh</code>, and <code>bin/herdr</code> first. Create / start / focus / close run through the helper with <code>HERDR_HELPER_OK=1</code>. The lantern acts on what you ask and stops to ask only when the target is unclear or the action destroys work you cannot get back.</p>
+      <p>Runs as you, with your environment. Read <code>launch.sh</code>, <code>lib.sh</code>, and <code>bin/herdr</code> first. Create / start / focus / close run through the helper with <code>HERDR_HELPER_OK=1</code>. The lantern acts on what you ask and stops to ask only when the ask itself is unclear: no target named, or a name that matches more than one.</p>
 
       <footer>
         Source: <a href="https://github.com/aigorahub/herdr-lantern">aigorahub/herdr-lantern</a>

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "aigora.lantern"
 name = "Lantern, by Elves"
-version = "0.9.9"
+version = "0.9.10"
 min_herdr_version = "0.7.5"
 description = "From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field."
 platforms = ["linux", "macos", "windows"]

--- a/howto.html
+++ b/howto.html
@@ -182,7 +182,7 @@
 <body>
   <main>
     <header>
-      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.9</p>
+      <p class="kicker">lantern, by elves · aigora.lantern · v0.9.10</p>
       <h1>Lantern, by Elves</h1>
       <p class="lede">From the team that brought you Elves. Herdr manages the herd. The herd is in the field. Lantern illuminates the field. You talk; it runs <code>herdr</code>. Each person picks their own helper CLI and model. Public walkthrough: <a href="https://aigorahub.github.io/herdr-lantern/">aigorahub.github.io/herdr-lantern</a>.</p>
     </header>
@@ -347,7 +347,7 @@ HELPER_EXTRA_ARGS=""</pre>
         <span>Optional. If Elves session files are around, it reads the floor. No Elves install required for the rest of Lantern.</span>
       </li>
     </ul>
-    <p class="note">Create / start / focus / close go through the helper, which reruns them with <code>HERDR_HELPER_OK=1</code>. Ask for something and the lantern does it, then tells you what it did. It stops to ask only when the target is unclear or the action destroys work: “clean everything up” asks which workspaces, and closing, killing, or removing asks once first.</p>
+    <p class="note">Create / start / focus / close go through the helper, which reruns them with <code>HERDR_HELPER_OK=1</code>. Ask for something and the lantern does it, then tells you what it did. It stops to ask only when the ask itself is unclear: “clean everything up” asks which workspaces, and a name matching two repositories asks which one. Closing, killing, and removing are not exceptions.</p>
 
     <p class="note">Source and README: <a href="https://github.com/aigorahub/herdr-lantern">aigorahub/herdr-lantern</a>.</p>
   </main>

--- a/launch.sh
+++ b/launch.sh
@@ -141,12 +141,12 @@ Runtime (injected by launch.sh; do not ignore):
   the user names the action and the target resolves to exactly one
   thing, run it and report what you did, naming the exact target. Never
   answer a request for work with \"Would you like me to?\". Ask one
-  short question first only when the target does not resolve to exactly
-  one thing or they never named it (\"clean up\", \"close that one\"), when
-  the action destroys work that is hard to get back (closing a
-  workspace, tab, or pane, agent kill, worktree remove, a plugin install
-  or reinstall), or when a model, repository, or saved session does not
-  resolve. Then act on the answer. Do not ask twice.
+  short question first only when the ask itself is unclear: the target
+  does not resolve to exactly one thing or they never named it
+  (\"clean up\", \"close that one\"), or a model, repository, or saved
+  session does not resolve. That is the whole list. Closing, killing,
+  and removing are not exceptions: named and resolved, they run like
+  anything else. Then act on the answer. Do not ask twice.
 - \`herdr agent prompt\` through the wrapper adds \`--wait\`. It presses
   Enter only when the target pane stalls with the text still showing
   (Cursor often types into the follow-up field without submitting), and
@@ -270,9 +270,10 @@ Runtime (injected by launch.sh; do not ignore):
   up to date or unavailable, say nothing about it. There is no
   \`herdr plugin update\`: a GitHub install refreshes with
   \`herdr plugin install aigorahub/herdr-lantern\`, which mutates the herd
-  and is gated like everything else — ask first, never upgrade silently. A
+  and is gated like everything else. Run it when they ask for it, and never
+  upgrade on your own. A
   linked checkout is never reinstalled over: say it is behind and leave the
-  pull to the user. After a confirmed install, tell the user to quit this
+  pull to the user. After the install, tell the user to quit this
   chat and reopen the lantern.
 - After workspace create, if agent start fails, wait two seconds and retry once
   (the new pane may still be coming up to a shell prompt).

--- a/prompt.md
+++ b/prompt.md
@@ -33,10 +33,10 @@ list` before you create anything. Reuse the workspace for the same cwd.
 | "Cursor review on XYZ", "have Cursor review that PR" | Use the named pull request route with Cursor plan mode. | Find the PR first. Use the live Cursor default unless the user named a model. |
 | "Grok review on XYZ", "have Cursor Grok review that PR" | Use the named pull request route with Cursor plan mode and a live Cursor Grok model. | Bare Grok means Cursor Ultra. |
 | "Grok Build review on XYZ", "have SuperGrok review that PR" | Use the named pull request route with Grok Build single-turn mode. | Use `--kind grok` and the live Grok Build default. |
-| "close finances", "close that tab/workspace" | `herdr workspace close <workspace_id>`, `herdr tab close <tab_id>`, or `herdr pane close <pane_id>` | Closing destroys work. Only act when the user names the target, and confirm the resolved target first. Never close Lantern home. |
-| "make a worktree", "open that worktree", "remove worktree X" | `herdr worktree create`, `herdr worktree open`, or `herdr worktree remove --workspace <id>` | Create and open on request. Removing destroys work: confirm the resolved worktree first, and remove only one the user names. |
+| "close finances", "close that tab/workspace" | `herdr workspace close <workspace_id>`, `herdr tab close <tab_id>`, or `herdr pane close <pane_id>` | Close it. Only act when the user names the target, and ask when the name matches more than one. Never close Lantern home. |
+| "make a worktree", "open that worktree", "remove worktree X" | `herdr worktree create`, `herdr worktree open`, or `herdr worktree remove --workspace <id>` | Create, open, and remove on request. Remove only a worktree the user names, and ask when the name matches more than one. |
 | "split right/down", "zoom this", "swap panes" | `herdr pane split`, `herdr pane zoom`, or `herdr pane swap` with the verified target and direction flags | Run when asked. Ask only when the pane or the direction is unclear. |
-| "list/install plugins", "update Lantern" | `herdr plugin list` or `herdr plugin install <owner/repo>` | List is read-only. Install is gated. Reinstall Lantern only after confirmation. |
+| "list/install plugins", "update Lantern" | `herdr plugin list` or `herdr plugin install <owner/repo>` | List is read-only. Install is gated. Reinstall Lantern when they ask for it, never on your own. |
 | "integration status/install" | `herdr integration status` or `herdr integration install <target>` | Status is read-only. Install is gated. |
 | "create a GitHub repo", "put this on GitHub", "make a repo" | `gh repo create <name> --private` | Always pass `--private`. Never `--public` unless the user explicitly asks for a public repo. |
 
@@ -288,12 +288,12 @@ words name that task.
      When the user names the action and the target resolves to exactly
      one thing, run it and report what you did. Never answer a request
      for work with "Would you like me to?".
-     Ask one short question first, and only in these cases: the target
-     does not resolve to exactly one thing, or they never named it
-     ("clean up", "close that one"); the action destroys work that is
-     hard to get back (closing a workspace, tab, or pane, `agent kill`,
-     `worktree remove`, a plugin install or reinstall); or a model,
-     repository, or saved session does not resolve. Ask the one specific
+     Ask one short question first, and only when the ask itself is
+     unclear: the target does not resolve to exactly one thing, or they
+     never named it ("clean up", "close that one"), or a model,
+     repository, or saved session does not resolve. That is the whole
+     list. Closing, killing, and removing are not exceptions: named and
+     resolved, they run like anything else. Ask the one specific
      question, then act on the answer. Do not ask twice, and do not ask
      again for something they already told you.
    - The gate rule. Read-only herdr runs as usual: `--help`, `status`,
@@ -400,8 +400,8 @@ Ground rules:
      about it.
    - There is no `herdr plugin update`. A GitHub install refreshes by
      running `herdr plugin install aigorahub/herdr-lantern` again. That
-     replaces the running plugin, so it is one of the ask-first cases:
-     ask once, then run it. Never upgrade silently.
+     replaces the running plugin. Run it when they ask for it. Never
+     upgrade on your own.
    - If `update.txt` says linked checkout, never run the install over
      it — reinstalling would orphan the link, and the checkout may hold
      work in progress. Say the checkout is behind and leave the

--- a/prompt.md
+++ b/prompt.md
@@ -406,7 +406,7 @@ Ground rules:
      it — reinstalling would orphan the link, and the checkout may hold
      work in progress. Say the checkout is behind and leave the
      `git pull` to the user.
-   - After a confirmed install, tell the user to quit this chat and
+   - After the install, tell the user to quit this chat and
      reopen the lantern: the new version loads at the next open, and
      this tab may stop answering to focus until it is closed.
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -176,10 +176,10 @@ for gated_verb in prompt send-keys start focus close remove; do
 done
 
 # A request is an instruction. The lantern acts on it and asks only when
-# the ask is genuinely unclear or the action destroys work. Both
-# instruction surfaces have to carry that rule and the short list of
-# cases that still stop for a question, or one of them quietly goes back
-# to asking permission for work the user already asked for.
+# the ask itself is unclear. Both instruction surfaces have to carry that
+# rule and the short list of cases that still stop for a question, or one
+# of them quietly goes back to asking permission for work the user
+# already asked for.
 for route_file in prompt.md launch.sh; do
     grep -qF 'Do what they asked' "$root/$route_file" ||
         fail "$route_file does not tell the lantern to act on a request"
@@ -187,10 +187,18 @@ for route_file in prompt.md launch.sh; do
         fail "$route_file does not say a request is an instruction"
     grep -qF 'Would you like me to?' "$root/$route_file" ||
         fail "$route_file does not forbid asking permission for work"
-    for ask_case in 'does not resolve' 'clean up' 'destroys work'; do
+    for ask_case in 'does not resolve' 'clean up'; do
         grep -qF "$ask_case" "$root/$route_file" ||
             fail "$route_file does not keep the $ask_case ask-first case"
     done
+    # Unclear is the only reason to ask. A destructive action the user
+    # named is still a clear request, and this is the carve-out that
+    # grew back once already.
+    if grep -qF 'destroys work' "$root/$route_file"; then
+        fail "$route_file asks for a confirmation the ask being unclear did not earn"
+    fi
+    grep -qF 'are not exceptions' "$root/$route_file" ||
+        fail "$route_file does not say closing and killing are not exceptions"
     if grep -qF 'Would you like me to open the tab?' "$root/$route_file"; then
         fail "$route_file still asks permission to open a tab"
     fi
@@ -205,12 +213,10 @@ for route_file in prompt.md launch.sh; do
         fail "$route_file still uses the old walk confirmation"
     fi
 done
-# Closing, killing, and removing are the actions a wrong guess cannot
-# undo. Those keep their question.
-for destructive in 'agent kill' 'worktree remove'; do
-    grep -qF "$destructive" "$root/prompt.md" ||
-        fail "prompt.md does not name $destructive as ask-first"
-done
+# The two rules that survive: an unnamed target is not a request, and
+# the lantern never closes its own home.
+grep -qF '"Clean up" / "I' "$root/prompt.md" ||
+    fail "prompt.md no longer refuses an unnamed clean up"
 grep -qF 'Never close Lantern home' "$root/prompt.md" ||
     fail "prompt.md must still protect the lantern home tab"
 grep -qF 'then run it' "$root/prompt.md" ||

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -193,9 +193,11 @@ for route_file in prompt.md launch.sh; do
     done
     # Unclear is the only reason to ask. A destructive action the user
     # named is still a clear request, and this is the carve-out that
-    # grew back once already.
-    if grep -qF 'destroys work' "$root/$route_file"; then
-        fail "$route_file asks for a confirmation the ask being unclear did not earn"
+    # grew back once already. One literal phrase is not enough of a
+    # guard: the same rule reworded reads the same to the lantern.
+    if grep -qiE 'destroys work|destructive|cannot be undone|hard to get back' \
+        "$root/$route_file"; then
+        fail "$route_file makes a destructive action its own reason to ask"
     fi
     grep -qF 'are not exceptions' "$root/$route_file" ||
         fail "$route_file does not say closing and killing are not exceptions"
@@ -213,12 +215,31 @@ for route_file in prompt.md launch.sh; do
         fail "$route_file still uses the old walk confirmation"
     fi
 done
+# The routes a wrong guess used to stop on are the ones a rewrite puts
+# a confirmation back into, and they can grow one without ever saying
+# "destroys work". Pin the rows themselves.
+for route_row in '"close finances"' '"make a worktree"' '"list/install plugins"'; do
+    row=$(grep -F "$route_row" "$root/prompt.md") ||
+        fail "prompt.md lost the $route_row route"
+    case $row in
+    *"only after confirmation"* | *"confirm the resolved"* | *"Confirm the resolved"*)
+        fail "the $route_row route waits for a confirmation again"
+        ;;
+    esac
+done
 # The two rules that survive: an unnamed target is not a request, and
 # the lantern never closes its own home.
 grep -qF '"Clean up" / "I' "$root/prompt.md" ||
     fail "prompt.md no longer refuses an unnamed clean up"
 grep -qF 'Never close Lantern home' "$root/prompt.md" ||
     fail "prompt.md must still protect the lantern home tab"
+# The walkthroughs describe the same posture to the user. Nothing kept
+# them honest before.
+for doc_file in README.md howto.html docs/index.html; do
+    if grep -qiE 'destroys work|destroy work' "$root/$doc_file"; then
+        fail "$doc_file still tells the user a destructive action asks first"
+    fi
+done
 grep -qF 'then run it' "$root/prompt.md" ||
     fail "prompt.md does not tell the lantern to run the seat plan"
 grep -qF '"walk me there"' "$root/prompt.md" ||


### PR DESCRIPTION
Corrects 0.9.9. That release said a request is an instruction, then kept a second reason to ask that the rule was never meant to have: the action being destructive. A named, resolved "close finances" is a clear request, and it stopped for a question anyway.

## Changed

Closing a workspace, tab, or pane, `agent kill`, `worktree remove`, and a plugin install now run like every other named request.

What still asks, and it is the whole list:

- The target does not resolve to exactly one thing, or was never named ("clean up", "close that one").
- A model, repository, or saved session does not resolve.

## Unchanged

The lantern never closes its own home tab, never acts on a target the user did not name, and never upgrades the plugin on its own. The `HERDR_HELPER_OK=1` gate in `bin/herdr` is unchanged; only its hint text drops the destructive clause.

## Files

`prompt.md`, the `launch.sh` appendix, `bin/herdr` hint, `README.md`, `howto.html`, `docs/index.html`, `CHANGELOG.md`, `tests/smoke.sh`. Version 0.9.10.

## Tests

`sh tests/smoke.sh` passes. Smoke now fails if either instruction surface says "destroys work" again, and requires both to say closing and killing are not exceptions. Verified the guard fires by reintroducing the old wording.